### PR TITLE
Remove Type.size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-xxx
+### Changed
+
+- `Type.size` was removed, advising to implement the corresponding functionality
+  outside of this module
 
 ## [2.0.0] - 2022-03-10
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,17 +180,6 @@ impl Type {
             other => other,
         }
     }
-
-    /// Returns byte size for values of the type
-    pub fn size(&self) -> u64 {
-        match self {
-            Self::Byte => 1,
-            Self::Halfword => 2,
-            Self::Word | Self::Single => 4,
-            // Aggregate types are syntactic sugar for pointers ;)
-            Self::Long | Self::Double | Self::Aggregate(_) => 8,
-        }
-    }
 }
 
 impl fmt::Display for Type {


### PR DESCRIPTION
### Description
It doesn't produce correct results for aggregates and needs a reference to the module if it wants to do so. I think it might be better to implement size measurement in the frontends instead.

### ToDo

- [ ] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable