### PR TITLE
Refactor Type::Aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-xxx
+### Added
+
+-   `Type::size()` can now correctly calculate the size of aggregate types
+    ([#12](https://github.com/garritfra/qbe-rs/pull/12)).
+
+### Changed
+
+-   `Type::Aggregate` now takes a `TypeDef` instead of the name of a type
+    ([#12](https://github.com/garritfra/qbe-rs/pull/12)).
 
 ## [2.0.0] - 2022-03-10
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,8 +187,15 @@ impl<'a> Type<'a> {
             Self::Byte => 1,
             Self::Halfword => 2,
             Self::Word | Self::Single => 4,
-            // Aggregate types are syntactic sugar for pointers ;)
-            Self::Long | Self::Double | Self::Aggregate(_) => 8,
+            Self::Long | Self::Double => 8,
+            Self::Aggregate(td) => {
+                // TODO: correct for alignment
+                let mut sz = 0_u64;
+                for (item, repeat) in td.items.iter() {
+                    sz += item.size() * (*repeat as u64);
+                }
+                sz
+            }
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -124,7 +124,32 @@ fn type_size() {
     };
     let aggregate = Type::Aggregate(&typedef);
     assert!(aggregate.size() == 17);
-    //assert!(aggregate.size() == 24);
+}
+
+#[test]
+fn type_size_nested_aggregate() {
+    let inner = TypeDef {
+        name: "dog".into(),
+        align: None,
+        items: vec![(Type::Long, 2)],
+    };
+    let inner_aggregate = Type::Aggregate(&inner);
+
+    assert!(inner_aggregate.size() == 16);
+
+    let typedef = TypeDef {
+        name: "person".into(),
+        align: None,
+        items: vec![
+            (Type::Long, 1),
+            (Type::Word, 2),
+            (Type::Byte, 1),
+            (Type::Aggregate(&inner), 1),
+        ],
+    };
+    let aggregate = Type::Aggregate(&typedef);
+
+    assert!(aggregate.size() == 33);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -109,6 +109,25 @@ fn typedef() {
 }
 
 #[test]
+fn type_size() {
+    assert!(Type::Byte.size() == 1);
+    assert!(Type::Halfword.size() == 2);
+    assert!(Type::Word.size() == 4);
+    assert!(Type::Single.size() == 4);
+    assert!(Type::Long.size() == 8);
+    assert!(Type::Double.size() == 8);
+
+    let typedef = TypeDef {
+        name: "person".into(),
+        align: None,
+        items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
+    };
+    let aggregate = Type::Aggregate(&typedef);
+    assert!(aggregate.size() == 17);
+    //assert!(aggregate.size() == 24);
+}
+
+#[test]
 fn type_into_abi() {
     // Base types and aggregates should stay unchanged
     let unchanged = |ty: Type| assert_eq!(ty.clone().into_abi(), ty);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -102,6 +102,10 @@ fn typedef() {
 
     let formatted = format!("{}", typedef);
     assert_eq!(formatted, "type :person = { l, w 2, b }");
+
+    let ty = Type::Aggregate(&typedef);
+    let formatted = format!("{}", ty);
+    assert_eq!(formatted, ":person");
 }
 
 #[test]
@@ -112,7 +116,12 @@ fn type_into_abi() {
     unchanged(Type::Long);
     unchanged(Type::Single);
     unchanged(Type::Double);
-    unchanged(Type::Aggregate("foo".into()));
+    let typedef = TypeDef {
+        name: "foo".into(),
+        align: None,
+        items: Vec::new(),
+    };
+    unchanged(Type::Aggregate(&typedef));
 
     // Extended types are transformed into closest base types
     assert_eq!(Type::Byte.into_abi(), Type::Word);
@@ -131,7 +140,12 @@ fn type_into_base() {
     // Extended and aggregate types are transformed into closest base types
     assert_eq!(Type::Byte.into_base(), Type::Word);
     assert_eq!(Type::Halfword.into_base(), Type::Word);
-    assert_eq!(Type::Aggregate("foo".into()).into_base(), Type::Long);
+    let typedef = TypeDef {
+        name: "foo".into(),
+        align: None,
+        items: Vec::new(),
+    };
+    assert_eq!(Type::Aggregate(&typedef).into_base(), Type::Long);
 }
 
 #[test]


### PR DESCRIPTION
### Description

Aggregate types weren't implemented quite right and caused various problems like `Type.size()` being broken. Now `Type::Aggregate` takes a reference to a `TypeDef` object, which it can use to calculate the size and assert correctness of the generated code because it would be a violation of Rust's rules to have an aggregate without a corresponding definition.

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
- [ ] The "Unreleased" section in the changelog has been updated, if applicable