### PR TITLE
Alignment overhaul

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,29 @@ impl<'a> Type<'a> {
         }
     }
 
+    /// Returns alignment of the type
+    pub fn align(&self) -> u64 {
+        match self {
+            Self::Byte => 1,
+            Self::Halfword => 2,
+            Self::Word | Self::Single => 4,
+            Self::Long | Self::Double => 8,
+            Self::Aggregate(td) => {
+                match td.align {
+                    Some(align) => align,
+                    None => {
+                        assert!(!td.items.is_empty(), "Invalid empty TypeDef");
+                        td.items
+                            .iter()
+                            .map(|(ty, _)| ty.align())
+                            .max()
+                            .unwrap()
+                    }
+                }
+            }
+        }
+    }
+
     /// Returns byte size for values of the type
     pub fn size(&self) -> u64 {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,12 +58,8 @@ pub enum Instr<'a> {
     Jmp(String),
     /// Calls a function
     Call(String, Vec<(Type<'a>, Value)>),
-    /// Allocates a 4-byte aligned area on the stack
-    Alloc4(u32),
-    /// Allocates a 8-byte aligned area on the stack
-    Alloc8(u64),
-    /// Allocates a 16-byte aligned area on the stack
-    Alloc16(u128),
+    /// Allocates an area on the stack
+    Alloc(u64, usize),
     /// Stores a value into memory pointed to by destination.
     /// `(type, destination, value)`
     Store(Type<'a>, Value, Value),
@@ -124,9 +120,13 @@ impl<'a> fmt::Display for Instr<'a> {
                         .join(", "),
                 )
             }
-            Self::Alloc4(size) => write!(f, "alloc4 {}", size),
-            Self::Alloc8(size) => write!(f, "alloc8 {}", size),
-            Self::Alloc16(size) => write!(f, "alloc16 {}", size),
+            Self::Alloc(size, align) => {
+                assert!(
+                    *align == 4 || *align == 8 || *align == 16,
+                    "Invalid stack alignment"
+                );
+                write!(f, "alloc{} {}", align, size)
+            }
             Self::Store(ty, dest, value) => {
                 if matches!(ty, Type::Aggregate(_)) {
                     unimplemented!("Store to an aggregate type");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -109,47 +109,40 @@ fn typedef() {
 }
 
 #[test]
-fn type_size() {
-    assert!(Type::Byte.size() == 1);
-    assert!(Type::Halfword.size() == 2);
-    assert!(Type::Word.size() == 4);
-    assert!(Type::Single.size() == 4);
-    assert!(Type::Long.size() == 8);
-    assert!(Type::Double.size() == 8);
+fn type_size_and_align() {
+    assert_eq!(Type::Byte.size(), 1);
+    assert_eq!(Type::Halfword.size(), 2);
+    assert_eq!(Type::Word.size(), 4);
+    assert_eq!(Type::Single.size(), 4);
+    assert_eq!(Type::Long.size(), 8);
+    assert_eq!(Type::Double.size(), 8);
 
-    let typedef = TypeDef {
+    let person = TypeDef {
         name: "person".into(),
         align: None,
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
     };
-    let aggregate = Type::Aggregate(&typedef);
-    assert!(aggregate.size() == 17);
-}
-
-#[test]
-fn type_size_nested_aggregate() {
-    let inner = TypeDef {
-        name: "dog".into(),
-        align: None,
-        items: vec![(Type::Long, 2)],
-    };
-    let inner_aggregate = Type::Aggregate(&inner);
-
-    assert!(inner_aggregate.size() == 16);
+    let aggregate = Type::Aggregate(&person);
+    assert_eq!(aggregate.align(), 8);
+    assert_eq!(aggregate.size(), 32);
 
     let typedef = TypeDef {
-        name: "person".into(),
+        name: "nested_person".into(),
         align: None,
-        items: vec![
-            (Type::Long, 1),
-            (Type::Word, 2),
-            (Type::Byte, 1),
-            (Type::Aggregate(&inner), 1),
-        ],
+        items: vec![(Type::Word, 1), (Type::Aggregate(&person), 1)],
     };
     let aggregate = Type::Aggregate(&typedef);
+    assert_eq!(aggregate.align(), 8);
+    assert_eq!(aggregate.size(), 40);
 
-    assert!(aggregate.size() == 33);
+    let typedef = TypeDef {
+        name: "packed_person".into(),
+        align: Some(1),
+        items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
+    };
+    let aggregate = Type::Aggregate(&typedef);
+    assert_eq!(aggregate.align(), 1);
+    assert_eq!(aggregate.size(), 17);
 }
 
 #[test]


### PR DESCRIPTION
### Description
Fixes issues related to field alignment in `Type.size()` and add `Type.align()` helper

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
- [ ] The "Unreleased" section in the changelog has been updated, if applicable