### PR TITLE
Change function args from `String` to `Into<String>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 
 -   `Type::Aggregate` now takes a `TypeDef` instead of the name of a type
     ([#12](https://github.com/garritfra/qbe-rs/pull/12)).
+-   Various `new()` functions now take `Into<String>` instead of a
+    `String` ([#15](https://github.com/garritfra/qbe-rs/pull/15))
 
 ## [2.0.0] - 2022-03-10
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,7 +5,7 @@ use qbe::*;
 fn generate_add_func(module: &mut Module) {
     let mut func = Function::new(
         Linkage::private(),
-        "add".into(),
+        "add",
         vec![
             (Type::Word, Value::Temporary("a".into())),
             (Type::Word, Value::Temporary("b".into())),
@@ -13,7 +13,7 @@ fn generate_add_func(module: &mut Module) {
         Some(Type::Word),
     );
 
-    func.add_block("start".into());
+    func.add_block("start");
     func.assign_instr(
         Value::Temporary("c".into()),
         Type::Word,
@@ -25,14 +25,9 @@ fn generate_add_func(module: &mut Module) {
 }
 
 fn generate_main_func(module: &mut Module) {
-    let mut func = Function::new(
-        Linkage::public(),
-        "main".into(),
-        Vec::new(),
-        Some(Type::Word),
-    );
+    let mut func = Function::new(Linkage::public(), "main", Vec::new(), Some(Type::Word));
 
-    func.add_block("start".into());
+    func.add_block("start");
     func.assign_instr(
         Value::Temporary("r".into()),
         Type::Word,
@@ -59,7 +54,7 @@ fn generate_data(module: &mut Module) {
         (Type::Byte, DataItem::Str("One and one make %d!\\n".into())),
         (Type::Byte, DataItem::Const(0)),
     ];
-    let data = DataDef::new(Linkage::private(), "fmt".into(), None, items);
+    let data = DataDef::new(Linkage::private(), "fmt", None, items);
     module.add_data(data);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,13 +247,13 @@ pub struct DataDef<'a> {
 impl<'a> DataDef<'a> {
     pub fn new(
         linkage: Linkage,
-        name: String,
+        name: impl Into<String>,
         align: Option<u64>,
         items: Vec<(Type<'a>, DataItem)>,
     ) -> Self {
         Self {
             linkage,
-            name,
+            name: name.into(),
             align,
             items,
         }
@@ -427,13 +427,13 @@ impl<'a> Function<'a> {
     /// Instantiates an empty function and returns it
     pub fn new(
         linkage: Linkage,
-        name: String,
+        name: impl Into<String>,
         arguments: Vec<(Type<'a>, Value)>,
         return_ty: Option<Type<'a>>,
     ) -> Self {
         Function {
             linkage,
-            name,
+            name: name.into(),
             arguments,
             return_ty,
             blocks: Vec::new(),
@@ -441,9 +441,9 @@ impl<'a> Function<'a> {
     }
 
     /// Adds a new empty block with a specified label and returns it
-    pub fn add_block(&mut self, label: String) {
+    pub fn add_block(&mut self, label: impl Into<String>) {
         self.blocks.push(Block {
-            label,
+            label: label.into(),
             statements: Vec::new(),
         });
     }
@@ -523,10 +523,10 @@ impl Linkage {
     }
 
     /// Returns the configuration for private linkage with a provided section
-    pub fn private_with_section(section: String) -> Linkage {
+    pub fn private_with_section(section: impl Into<String>) -> Linkage {
         Linkage {
             exported: false,
-            section: Some(section),
+            section: Some(section.into()),
             secflags: None,
         }
     }
@@ -541,10 +541,10 @@ impl Linkage {
     }
 
     /// Returns the configuration for public linkage with a provided section
-    pub fn public_with_section(section: String) -> Linkage {
+    pub fn public_with_section(section: impl Into<String>) -> Linkage {
         Linkage {
             exported: true,
-            section: Some(section),
+            section: Some(section.into()),
             secflags: None,
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -74,6 +74,21 @@ fn function() {
 }
 
 #[test]
+fn function_new_equivalence() {
+    let func1 = Function {
+        linkage: Linkage::public(),
+        return_ty: None,
+        name: "main".into(),
+        arguments: Vec::new(),
+        blocks: Vec::new(),
+    };
+
+    let func2 = Function::new(Linkage::public(), "main", Vec::new(), None);
+
+    assert_eq!(func1, func2);
+}
+
+#[test]
 fn datadef() {
     let datadef = DataDef {
         linkage: Linkage::public(),
@@ -90,6 +105,20 @@ fn datadef() {
         formatted,
         "export data $hello = { b \"Hello, World!\", b 0 }"
     );
+}
+
+#[test]
+fn datadef_new_equivalence() {
+    let datadef1 = DataDef {
+        linkage: Linkage::public(),
+        name: "hello".into(),
+        align: None,
+        items: vec![],
+    };
+
+    let datadef2 = DataDef::new(Linkage::public(), "hello", None, vec![]);
+
+    assert_eq!(datadef1, datadef2);
 }
 
 #[test]


### PR DESCRIPTION

### Description

Doesn't help quite as much as one might hope because there's
still lots of structures that you build literally, and those all
contain `String` and kind of have to.  If you want me to make
constructor functions for those I will, but that's an API decision
I happily leave up to you.

Fixes #14 


### Changes proposed in this pull request

As in the description

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable