### PR TITLE
Constructors taking `Into<String>` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 
 -   `Type::Aggregate` now takes a `TypeDef` instead of the name of a type
     ([#12](https://github.com/garritfra/qbe-rs/pull/12)).
+-   Various `new()` functions now take `Into<String>` instead of a
+    `String` ([#15](https://github.com/garritfra/qbe-rs/pull/15))
 
 ## [2.0.0] - 2022-03-10
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,7 +5,7 @@ use qbe::*;
 fn generate_add_func(module: &mut Module) {
     let mut func = Function::new(
         Linkage::private(),
-        "add".into(),
+        "add",
         vec![
             (Type::Word, Value::Temporary("a".into())),
             (Type::Word, Value::Temporary("b".into())),
@@ -13,7 +13,7 @@ fn generate_add_func(module: &mut Module) {
         Some(Type::Word),
     );
 
-    func.add_block("start".into());
+    func.add_block("start");
     func.assign_instr(
         Value::Temporary("c".into()),
         Type::Word,
@@ -25,14 +25,9 @@ fn generate_add_func(module: &mut Module) {
 }
 
 fn generate_main_func(module: &mut Module) {
-    let mut func = Function::new(
-        Linkage::public(),
-        "main".into(),
-        Vec::new(),
-        Some(Type::Word),
-    );
+    let mut func = Function::new(Linkage::public(), "main", Vec::new(), Some(Type::Word));
 
-    func.add_block("start".into());
+    func.add_block("start");
     func.assign_instr(
         Value::Temporary("r".into()),
         Type::Word,
@@ -59,7 +54,7 @@ fn generate_data(module: &mut Module) {
         (Type::Byte, DataItem::Str("One and one make %d!\\n".into())),
         (Type::Byte, DataItem::Const(0)),
     ];
-    let data = DataDef::new(Linkage::private(), "fmt".into(), None, items);
+    let data = DataDef::new(Linkage::private(), "fmt", None, items);
     module.add_data(data);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,20 @@ impl fmt::Display for Value {
     }
 }
 
+impl Value {
+    pub fn temporary(s: impl Into<String>) -> Self {
+        Value::Temporary(s.into())
+    }
+
+    pub fn global(s: impl Into<String>) -> Self {
+        Value::Global(s.into())
+    }
+
+    pub fn const_(n: u64) -> Self {
+        Value::Const(n)
+    }
+}
+
 /// QBE data definition
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct DataDef<'a> {
@@ -303,6 +317,20 @@ impl fmt::Display for DataItem {
     }
 }
 
+impl DataItem {
+    pub fn symbol(symbol: impl Into<String>, offset: Option<u64>) -> Self {
+        DataItem::Symbol(symbol.into(), offset)
+    }
+
+    pub fn str(s: impl Into<String>) -> Self {
+        DataItem::Str(s.into())
+    }
+
+    pub fn const_(n: u64) -> Self {
+        DataItem::Const(n)
+    }
+}
+
 /// QBE aggregate type definition
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct TypeDef<'a> {
@@ -332,6 +360,16 @@ impl<'a> fmt::Display for TypeDef<'a> {
                 .collect::<Vec<String>>()
                 .join(", "),
         )
+    }
+}
+
+impl<'a> TypeDef<'a> {
+    pub fn new(name: impl Into<String>, align: Option<u64>, items: Vec<(Type<'a>, usize)>) -> Self {
+        TypeDef {
+            name: name.into(),
+            align,
+            items,
+        }
     }
 }
 
@@ -365,6 +403,13 @@ pub struct Block<'a> {
 }
 
 impl<'a> Block<'a> {
+    pub fn new(label: impl Into<String>, statements: Vec<Statement<'a>>) -> Self {
+        Block {
+            label: label.into(),
+            statements,
+        }
+    }
+
     /// Adds a new instruction to the block
     pub fn add_instr(&mut self, instr: Instr<'a>) {
         self.statements.push(Statement::Volatile(instr));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,13 +247,13 @@ pub struct DataDef<'a> {
 impl<'a> DataDef<'a> {
     pub fn new(
         linkage: Linkage,
-        name: String,
+        name: impl Into<String>,
         align: Option<u64>,
         items: Vec<(Type<'a>, DataItem)>,
     ) -> Self {
         Self {
             linkage,
-            name,
+            name: name.into(),
             align,
             items,
         }
@@ -427,13 +427,13 @@ impl<'a> Function<'a> {
     /// Instantiates an empty function and returns it
     pub fn new(
         linkage: Linkage,
-        name: String,
+        name: impl Into<String>,
         arguments: Vec<(Type<'a>, Value)>,
         return_ty: Option<Type<'a>>,
     ) -> Self {
         Function {
             linkage,
-            name,
+            name: name.into(),
             arguments,
             return_ty,
             blocks: Vec::new(),
@@ -441,9 +441,9 @@ impl<'a> Function<'a> {
     }
 
     /// Adds a new empty block with a specified label and returns it
-    pub fn add_block(&mut self, label: String) {
+    pub fn add_block(&mut self, label: impl Into<String>) {
         self.blocks.push(Block {
-            label,
+            label: label.into(),
             statements: Vec::new(),
         });
     }
@@ -523,10 +523,10 @@ impl Linkage {
     }
 
     /// Returns the configuration for private linkage with a provided section
-    pub fn private_with_section(section: String) -> Linkage {
+    pub fn private_with_section(section: impl Into<String>) -> Linkage {
         Linkage {
             exported: false,
-            section: Some(section),
+            section: Some(section.into()),
             secflags: None,
         }
     }
@@ -541,10 +541,10 @@ impl Linkage {
     }
 
     /// Returns the configuration for public linkage with a provided section
-    pub fn public_with_section(section: String) -> Linkage {
+    pub fn public_with_section(section: impl Into<String>) -> Linkage {
         Linkage {
             exported: true,
-            section: Some(section),
+            section: Some(section.into()),
             secflags: None,
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -74,6 +74,21 @@ fn function() {
 }
 
 #[test]
+fn function_new_equivalence() {
+    let func1 = Function {
+        linkage: Linkage::public(),
+        return_ty: None,
+        name: "main".into(),
+        arguments: Vec::new(),
+        blocks: Vec::new(),
+    };
+
+    let func2 = Function::new(Linkage::public(), "main", Vec::new(), None);
+
+    assert_eq!(func1, func2);
+}
+
+#[test]
 fn datadef() {
     let datadef = DataDef {
         linkage: Linkage::public(),
@@ -90,6 +105,20 @@ fn datadef() {
         formatted,
         "export data $hello = { b \"Hello, World!\", b 0 }"
     );
+}
+
+#[test]
+fn datadef_new_equivalence() {
+    let datadef1 = DataDef {
+        linkage: Linkage::public(),
+        name: "hello".into(),
+        align: None,
+        items: vec![],
+    };
+
+    let datadef2 = DataDef::new(Linkage::public(), "hello", None, vec![]);
+
+    assert_eq!(datadef1, datadef2);
 }
 
 #[test]


### PR DESCRIPTION
### Description

Adds various `new()` funcs taking `Into<String>`
    
This is basically just boilerplate, as discussed in #15.  This is in its own PR so you can decide separately whether or not you want it.  It's not really finished, just intended as a sample for discussion.


### Changes proposed in this pull request

- Add `new()` functions for most/all types so that we can take `Into<String>` for names instead of just Strings.

### ToDo


Still need to do for this:
    
- [ ] Add functions for `Instr` struct
- [ ] Proposed feature/fix is sufficiently tested
- [ ] Proposed feature/fix is sufficiently documented
- [ ] The "Unreleased" section in the changelog has been updated, if applicable