### PR TITLE
feat(functions): return mutatble reference from add_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ All notable changes to this project will be documented in this file.
 
 -   `Type::size()` can now correctly calculate the size of aggregate types
     ([#12](https://github.com/garritfra/qbe-rs/pull/12)).
+-   `Function::add_block()` returns a reference to the created block ([#18](https://github.com/garritfra/qbe-rs/pull/18))
 
 ### Changed
 
 -   `Type::Aggregate` now takes a `TypeDef` instead of the name of a type
     ([#12](https://github.com/garritfra/qbe-rs/pull/12)).
+-   Deprecated `Function::last_block()` ([#18](https://github.com/garritfra/qbe-rs/pull/18))
 
 ## [2.0.0] - 2022-03-10
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,14 +440,20 @@ impl<'a> Function<'a> {
         }
     }
 
-    /// Adds a new empty block with a specified label and returns it
-    pub fn add_block(&mut self, label: String) {
+    /// Adds a new empty block with a specified label and returns a reference to it
+    pub fn add_block(&mut self, label: String) -> &mut Block<'a> {
         self.blocks.push(Block {
             label,
             statements: Vec::new(),
         });
+        self.blocks.last_mut().unwrap()
     }
 
+    /// Returns a reference to the last block
+    #[deprecated(
+        since = "3.0.0",
+        note = "Use `self.blocks.last()` or `self.blocks.last_mut()` instead."
+    )]
     pub fn last_block(&mut self) -> &Block {
         self.blocks
             .last()


### PR DESCRIPTION
Fixes #17 

### Description

`Function::add_block()` should return a reference to the created block.

### Changes proposed in this pull request

- `Function::add_block()` returns a reference to the created block
- Deprecated `Function::last_block()`, since it's mostly unnecessary

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable