### PR TITLE
Add unsigned and signed variants of sub-word types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 -   Various `new()` functions now take `Into<String>` instead of a
     `String` ([#15](https://github.com/garritfra/qbe-rs/pull/15))
+-   Add unsigned and signed variants of sub-word types: `Type::SignedByte`, `Type::UnsignedByte`, `Type::SignedHalfword`, `Type::UnsignedHalfword` ([#23](https://github.com/garritfra/qbe-rs/pull/23))
 
 ## [2.1.0] - 2022-12-15
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,11 @@ pub enum Type<'a> {
 
     // Extended types
     Byte,
+    SignedByte,
+    UnsignedByte,
     Halfword,
+    SignedHalfword,
+    UnsignedHalfword,
 
     /// Aggregate type with a specified name
     Aggregate(&'a TypeDef<'a>),
@@ -177,7 +181,12 @@ impl<'a> Type<'a> {
     /// types
     pub fn into_abi(self) -> Self {
         match self {
-            Self::Byte | Self::Halfword => Self::Word,
+            Self::Byte
+            | Self::SignedByte
+            | Self::UnsignedByte
+            | Self::Halfword
+            | Self::SignedHalfword
+            | Self::UnsignedHalfword => Self::Word,
             other => other,
         }
     }
@@ -185,7 +194,12 @@ impl<'a> Type<'a> {
     /// Returns the closest base type
     pub fn into_base(self) -> Self {
         match self {
-            Self::Byte | Self::Halfword => Self::Word,
+            Self::Byte
+            | Self::SignedByte
+            | Self::UnsignedByte
+            | Self::Halfword
+            | Self::SignedHalfword
+            | Self::UnsignedHalfword => Self::Word,
             Self::Aggregate(_) => Self::Long,
             other => other,
         }
@@ -194,8 +208,8 @@ impl<'a> Type<'a> {
     /// Returns byte size for values of the type
     pub fn size(&self) -> u64 {
         match self {
-            Self::Byte => 1,
-            Self::Halfword => 2,
+            Self::Byte | Self::SignedByte | Self::UnsignedByte => 1,
+            Self::Halfword | Self::SignedHalfword | Self::UnsignedHalfword => 2,
             Self::Word | Self::Single => 4,
             Self::Long | Self::Double => 8,
             Self::Aggregate(td) => {
@@ -214,7 +228,11 @@ impl<'a> fmt::Display for Type<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Byte => write!(f, "b"),
+            Self::SignedByte => write!(f, "sb"),
+            Self::UnsignedByte => write!(f, "ub"),
             Self::Halfword => write!(f, "h"),
+            Self::SignedHalfword => write!(f, "sh"),
+            Self::UnsignedHalfword => write!(f, "uh"),
             Self::Word => write!(f, "w"),
             Self::Long => write!(f, "l"),
             Self::Single => write!(f, "s"),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,7 +157,11 @@ fn typedef() {
 #[test]
 fn type_size() {
     assert!(Type::Byte.size() == 1);
+    assert!(Type::SignedByte.size() == 1);
+    assert!(Type::UnsignedByte.size() == 1);
     assert!(Type::Halfword.size() == 2);
+    assert!(Type::SignedHalfword.size() == 2);
+    assert!(Type::UnsignedHalfword.size() == 2);
     assert!(Type::Word.size() == 4);
     assert!(Type::Single.size() == 4);
     assert!(Type::Long.size() == 8);
@@ -215,7 +219,11 @@ fn type_into_abi() {
 
     // Extended types are transformed into closest base types
     assert_eq!(Type::Byte.into_abi(), Type::Word);
+    assert_eq!(Type::UnsignedByte.into_abi(), Type::Word);
+    assert_eq!(Type::SignedByte.into_abi(), Type::Word);
     assert_eq!(Type::Halfword.into_abi(), Type::Word);
+    assert_eq!(Type::UnsignedHalfword.into_abi(), Type::Word);
+    assert_eq!(Type::SignedHalfword.into_abi(), Type::Word);
 }
 
 #[test]
@@ -229,7 +237,11 @@ fn type_into_base() {
 
     // Extended and aggregate types are transformed into closest base types
     assert_eq!(Type::Byte.into_base(), Type::Word);
+    assert_eq!(Type::UnsignedByte.into_base(), Type::Word);
+    assert_eq!(Type::SignedHalfword.into_base(), Type::Word);
     assert_eq!(Type::Halfword.into_base(), Type::Word);
+    assert_eq!(Type::UnsignedHalfword.into_base(), Type::Word);
+    assert_eq!(Type::SignedHalfword.into_base(), Type::Word);
     let typedef = TypeDef {
         name: "foo".into(),
         align: None,


### PR DESCRIPTION
### Description

Adds unsigned and signed variants of sub-word types, required for some instructions.

### Changes proposed in this pull request

- Adds `Type::SignedByte`, `Type::UnsignedByte`, `Type::SignedHalfword`, `Type::UnsignedHalfword`.

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable