### PR TITLE
Add support for variadic marker in `Instr::Call`

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -34,15 +34,16 @@ fn generate_main_func(module: &mut Module) {
         Instr::Call(
             "add".into(),
             vec![(Type::Word, Value::Const(1)), (Type::Word, Value::Const(1))],
+            None,
         ),
     );
-    // TODO: The example shows a variadic call. We don't have those yet
     func.add_instr(Instr::Call(
         "printf".into(),
         vec![
             (Type::Long, Value::Global("fmt".into())),
             (Type::Word, Value::Temporary("r".into())),
         ],
+        Some(1),
     ));
     func.add_instr(Instr::Ret(Some(Value::Const(0))));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub enum Instr<'a> {
     /// Unconditionally jumps to a label
     Jmp(String),
     /// Calls a function
-    Call(String, Vec<(Type<'a>, Value)>),
+    Call(String, Vec<(Type<'a>, Value)>, Option<u64>),
     /// Allocates a 4-byte aligned area on the stack
     Alloc4(u32),
     /// Allocates a 8-byte aligned area on the stack
@@ -122,16 +122,16 @@ impl<'a> fmt::Display for Instr<'a> {
                 write!(f, "jnz {}, @{}, @{}", val, if_nonzero, if_zero)
             }
             Self::Jmp(label) => write!(f, "jmp @{}", label),
-            Self::Call(name, args) => {
-                write!(
-                    f,
-                    "call ${}({})",
-                    name,
-                    args.iter()
-                        .map(|(ty, temp)| format!("{} {}", ty, temp))
-                        .collect::<Vec<String>>()
-                        .join(", "),
-                )
+            Self::Call(name, args, opt_variadic_i) => {
+                let mut args_fmt = args
+                    .iter()
+                    .map(|(ty, temp)| format!("{} {}", ty, temp))
+                    .collect::<Vec<String>>();
+                if let Some(i) = *opt_variadic_i {
+                    args_fmt.insert(i as usize, "...".to_string());
+                }
+
+                write!(f, "call ${}({})", name, args_fmt.join(", "),)
             }
             Self::Alloc4(size) => write!(f, "alloc4 {}", size),
             Self::Alloc8(size) => write!(f, "alloc8 {}", size),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -266,3 +266,17 @@ fn add_function_to_module() {
 
     assert_eq!(module.functions.into_iter().next().unwrap(), function);
 }
+
+#[test]
+fn variadic_call() {
+    let instr = Instr::Call(
+        "printf".into(),
+        vec![
+            (Type::Long, Value::Global("fmt".into())),
+            (Type::Word, Value::Const(0)),
+        ],
+        Some(1),
+    );
+
+    assert_eq!(instr.to_string(), "call $printf(l $fmt, ..., w 0)");
+}


### PR DESCRIPTION
Doesn't quite fix https://github.com/garritfra/qbe-rs/issues/4 as that would require changes to `qbe_rs::Function` too, but at least this enables calling variadic functions which is nice when interfacing with libc.

Thanks for the very handy library, I'm having a blast with it in my hobby project.