### PR TITLE
New API for defining comments inside blocks: `Block::add_comment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-xxx
+### Added
+
+-   New `Block::add_comment` API to add comments inside blocks; `Block::items` is now `Vec<BlockItem>` instead of `Vec<Statement>` ([#25](https://github.com/garritfra/qbe-rs/pull/25)).
+
+### Changed
+
+-   New field `Option<u64>` inside `Instr::Call` to specify variadic arguments ([#24](https://github.com/garritfra/qbe-rs/pull/24)).
 
 ## [2.2.0] - 2024-10-28
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,26 +389,50 @@ pub struct Block<'a> {
     pub label: String,
 
     /// A list of statements in the block
-    pub statements: Vec<Statement<'a>>,
+    pub items: Vec<BlockItem<'a>>,
+}
+
+/// See [`Block::items`];
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum BlockItem<'a> {
+    Statement(Statement<'a>),
+    Comment(String),
+}
+
+impl<'a> fmt::Display for BlockItem<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Statement(stmt) => write!(f, "{}", stmt),
+            Self::Comment(comment) => write!(f, "# {}", comment),
+        }
+    }
 }
 
 impl<'a> Block<'a> {
+    pub fn add_comment(&mut self, contents: impl Into<String>) {
+        self.items.push(BlockItem::Comment(contents.into()));
+    }
+
     /// Adds a new instruction to the block
     pub fn add_instr(&mut self, instr: Instr<'a>) {
-        self.statements.push(Statement::Volatile(instr));
+        self.items
+            .push(BlockItem::Statement(Statement::Volatile(instr)));
     }
 
     /// Adds a new instruction assigned to a temporary
     pub fn assign_instr(&mut self, temp: Value, ty: Type<'a>, instr: Instr<'a>) {
-        self.statements
-            .push(Statement::Assign(temp, ty.into_base(), instr));
+        self.items.push(BlockItem::Statement(Statement::Assign(
+            temp,
+            ty.into_base(),
+            instr,
+        )));
     }
 
     /// Returns true if the block's last instruction is a jump
     pub fn jumps(&self) -> bool {
-        let last = self.statements.last();
+        let last = self.items.last();
 
-        if let Some(Statement::Volatile(instr)) = last {
+        if let Some(BlockItem::Statement(Statement::Volatile(instr))) = last {
             matches!(instr, Instr::Ret(_) | Instr::Jmp(_) | Instr::Jnz(..))
         } else {
             false
@@ -423,7 +447,7 @@ impl<'a> fmt::Display for Block<'a> {
         write!(
             f,
             "{}",
-            self.statements
+            self.items
                 .iter()
                 .map(|instr| format!("\t{}", instr))
                 .collect::<Vec<String>>()
@@ -472,7 +496,7 @@ impl<'a> Function<'a> {
     pub fn add_block(&mut self, label: impl Into<String>) -> &mut Block<'a> {
         self.blocks.push(Block {
             label: label.into(),
-            statements: Vec::new(),
+            items: Vec::new(),
         });
         self.blocks.last_mut().unwrap()
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,7 +25,7 @@ fn qbe_value() {
 fn block() {
     let blk = Block {
         label: "start".into(),
-        statements: vec![Statement::Volatile(Instr::Ret(None))],
+        items: vec![BlockItem::Statement(Statement::Volatile(Instr::Ret(None)))],
     };
 
     let formatted = format!("{}", blk);
@@ -35,19 +35,23 @@ fn block() {
 
     let blk = Block {
         label: "start".into(),
-        statements: vec![
-            Statement::Assign(
+        items: vec![
+            BlockItem::Comment("Comment".into()),
+            BlockItem::Statement(Statement::Assign(
                 Value::Temporary("foo".into()),
                 Type::Word,
                 Instr::Add(Value::Const(2), Value::Const(2)),
-            ),
-            Statement::Volatile(Instr::Ret(Some(Value::Temporary("foo".into())))),
+            )),
+            BlockItem::Statement(Statement::Volatile(Instr::Ret(Some(Value::Temporary(
+                "foo".into(),
+            ))))),
         ],
     };
 
     let formatted = format!("{}", blk);
     let mut lines = formatted.lines();
     assert_eq!(lines.next().unwrap(), "@start");
+    assert_eq!(lines.next().unwrap(), "\t# Comment");
     assert_eq!(lines.next().unwrap(), "\t%foo =w add 2, 2");
     assert_eq!(lines.next().unwrap(), "\tret %foo");
 }
@@ -56,11 +60,11 @@ fn block() {
 fn instr_blit() {
     let blk = Block {
         label: "start".into(),
-        statements: vec![Statement::Volatile(Instr::Blit(
+        items: vec![BlockItem::Statement(Statement::Volatile(Instr::Blit(
             Value::Temporary("src".into()),
             Value::Temporary("dst".into()),
             4,
-        ))],
+        )))],
     };
 
     let formatted = format!("{}", blk);
@@ -78,7 +82,7 @@ fn function() {
         arguments: Vec::new(),
         blocks: vec![Block {
             label: "start".into(),
-            statements: vec![Statement::Volatile(Instr::Ret(None))],
+            items: vec![BlockItem::Statement(Statement::Volatile(Instr::Ret(None)))],
         }],
     };
 


### PR DESCRIPTION
`Block::items` used to be a `Vec<Statement>` but we can turn it into a `Vec<BlockItem>` and add support for comments.

Note, the spec allows for comments everywhere in source files, not just inside blocks, and this PR only allows comments inside blocks. I don't particularly like that and I'm open to reworking my approach if you have any ideas!

Also added a changelog entry for both this PR as well as #24.

- [x] Modified a test to generate a comment, and check the output.