### PR TITLE
Update lib.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-xxx
+### Fixed
+
+- Fixed type definition ordering in `Module::fmt::Display` to ensure type definitions appear before function definitions, which is required by QBE for aggregate types ([#31](https://github.com/garritfra/qbe-rs/pull/31)).
 
 ## [2.3.0] - 2025-01-13
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,11 +683,11 @@ impl<'a> Module<'a> {
 
 impl fmt::Display for Module<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for func in self.functions.iter() {
-            writeln!(f, "{}", func)?;
-        }
         for ty in self.types.iter() {
             writeln!(f, "{}", ty)?;
+        }
+        for func in self.functions.iter() {
+            writeln!(f, "{}", func)?;
         }
         for data in self.data.iter() {
             writeln!(f, "{}", data)?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -289,7 +289,7 @@ fn variadic_call() {
 fn module_fmt_order() {
     // Create a module
     let mut module = Module::new();
-    
+
     // Add a type definition to the module
     let typedef = TypeDef {
         name: "test_type".into(),
@@ -297,38 +297,45 @@ fn module_fmt_order() {
         items: vec![(Type::Long, 1)],
     };
     module.add_type(typedef);
-    
+
     // Add a function to the module
-    let mut func = Function::new(
-        Linkage::public(),
-        "test_func",
-        Vec::new(),
-        None
-    );
-    
+    let mut func = Function::new(Linkage::public(), "test_func", Vec::new(), None);
+
     // Add a block to the function and an instruction to the block
     let block = func.add_block("entry");
     block.add_instr(Instr::Ret(None));
-    
+
     module.add_function(func);
-    
+
     // Add some data to the module for completeness
     let data = DataDef::new(
         Linkage::private(),
         "test_data",
         None,
-        vec![(Type::Word, DataItem::Const(42))]
+        vec![(Type::Word, DataItem::Const(42))],
     );
     module.add_data(data);
-    
+
     // Format the module to a string
     let formatted = format!("{}", module);
-    
+
     // Verify the order: types, then functions, then data
-    let type_pos = formatted.find("type :test_type").expect("Type definition not found");
-    let func_pos = formatted.find("export function $test_func").expect("Function not found");
-    let data_pos = formatted.find("data $test_data").expect("Data definition not found");
-    
-    assert!(type_pos < func_pos, "Type definition should appear before function");
-    assert!(func_pos < data_pos, "Function should appear before data definition");
+    let type_pos = formatted
+        .find("type :test_type")
+        .expect("Type definition not found");
+    let func_pos = formatted
+        .find("export function $test_func")
+        .expect("Function not found");
+    let data_pos = formatted
+        .find("data $test_data")
+        .expect("Data definition not found");
+
+    assert!(
+        type_pos < func_pos,
+        "Type definition should appear before function"
+    );
+    assert!(
+        func_pos < data_pos,
+        "Function should appear before data definition"
+    );
 }


### PR DESCRIPTION
Reordered `impl::Display` to ensure aggregate types are defined before any usage

Fixes #30 
### Description
`Module<'_>`'s `fmt::Display` impl to ensure aggregate types are defined before usage, to conform with QBE.

### Changes proposed in this pull request
Update `Module<'_>`'s `fmt::Display`

### ToDo

- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable