### PR TITLE
Correct size and alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Code documentation examples
+- Alignment calculation for type definition
+
+### Fixed
+
+- Correct size calculation for type definition
 
 ## [2.4.0] - 2025-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Code documentation examples
-- Alignment calculation for type definition
+- Alignment calculation for type definition ([#33](https://github.com/garritfra/qbe-rs/pull/33))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Correct size calculation for type definition
+- Correct size calculation for type definition ([#33](https://github.com/garritfra/qbe-rs/pull/33))
 
 ## [2.4.0] - 2025-02-28
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,27 @@ impl Type<'_> {
             }
         }
     }
+
+    /// Returns byte alignment for values of the type
+    pub fn align(&self) -> u64 {
+        match self {
+            Self::Aggregate(td) => {
+                if let Some(align) = td.align {
+                    return align;
+                }
+
+                // the alignment of a type is the maximum alignment of its members
+                // when there's no members, the alignment is usuallly defined to be 1.
+                td.items
+                    .iter()
+                    .map(|item| item.0.align())
+                    .max()
+                    .unwrap_or(1)
+            }
+
+            _ => self.size(),
+        }
+    }
 }
 
 impl fmt::Display for Type<'_> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -177,7 +177,7 @@ fn type_size() {
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
     };
     let aggregate = Type::Aggregate(&typedef);
-    assert!(aggregate.size() == 17);
+    assert_eq!(aggregate.size(), 24);
 }
 
 #[test]
@@ -203,7 +203,7 @@ fn type_size_nested_aggregate() {
     };
     let aggregate = Type::Aggregate(&typedef);
 
-    assert!(aggregate.size() == 33);
+    assert_eq!(aggregate.size(), 40);
 }
 
 #[test]


### PR DESCRIPTION
### Description

This PR is an implementation for the size and alignment calculation of a type definition, as described in [Wikipedia](https://en.wikipedia.org/wiki/Data_structure_alignment#Computing%20padding)

### Changes proposed in this pull request

- Add a method that returns the alignment of a type
- Fix the size calculation of type definition, by considering alignment and padding  

### ToDo

- [x] I've read the [CONTRIBUTING.md](https://github.com/garritfra/qbe-rs/blob/main/CONTRIBUTING.md) guidelines before submitting this PR
- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable