### PR TITLE
Fix invalid sub-word load/store instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-xxx
+### Fixed
+
+- BREAKING: `Load` with `Type::Byte` or `Type::Halfword` now panics instead of emitting invalid `loadb`/`loadh` instructions. Use `SignedByte`/`UnsignedByte` or `SignedHalfword`/`UnsignedHalfword` instead. ([#51](https://github.com/garritfra/qbe-rs/issues/51))
+- `Store` with signed/unsigned sub-word types (`SignedByte`, `UnsignedByte`, `SignedHalfword`, `UnsignedHalfword`) now correctly emits `storeb`/`storeh` instead of invalid `storesb`/`storeub`/`storesh`/`storeuh`
+
+### Migration guide
+
+#### Sub-word loads
+
+`Load` with `Type::Byte` or `Type::Halfword` previously emitted invalid QBE IL (`loadb`/`loadh`). These now panic at runtime. Replace with the explicit signed/unsigned variant:
+
+```rust
+// Before (produced invalid QBE IL)
+Instr::Load(Type::Byte, src)
+Instr::Load(Type::Halfword, src)
+
+// After — choose signed or unsigned extension
+Instr::Load(Type::SignedByte, src)    // emits loadsb
+Instr::Load(Type::UnsignedByte, src)  // emits loadub
+Instr::Load(Type::SignedHalfword, src)    // emits loadsh
+Instr::Load(Type::UnsignedHalfword, src)  // emits loaduh
+```
+
+#### Sub-word stores (non-breaking)
+
+`Store` with `Type::SignedByte`, `Type::UnsignedByte`, `Type::SignedHalfword`, or `Type::UnsignedHalfword` previously emitted invalid instructions (`storesb`, `storeub`, etc.). These now correctly emit `storeb`/`storeh`. No code changes needed — existing code using these types will silently produce correct output.
 
 ## [3.0.0] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- BREAKING: `Load` with `Type::Byte` or `Type::Halfword` now panics instead of emitting invalid `loadb`/`loadh` instructions. Use `SignedByte`/`UnsignedByte` or `SignedHalfword`/`UnsignedHalfword` instead. ([#51](https://github.com/garritfra/qbe-rs/issues/51))
-- `Store` with signed/unsigned sub-word types (`SignedByte`, `UnsignedByte`, `SignedHalfword`, `UnsignedHalfword`) now correctly emits `storeb`/`storeh` instead of invalid `storesb`/`storeub`/`storesh`/`storeuh`
+- BREAKING: `Load` with `Type::Byte` or `Type::Halfword` now panics instead of emitting invalid `loadb`/`loadh` instructions. Use `SignedByte`/`UnsignedByte` or `SignedHalfword`/`UnsignedHalfword` instead. ([#51](https://github.com/garritfra/qbe-rs/issues/51), [#54](https://github.com/garritfra/qbe-rs/pull/54))
+- `Store` with signed/unsigned sub-word types (`SignedByte`, `UnsignedByte`, `SignedHalfword`, `UnsignedHalfword`) now correctly emits `storeb`/`storeh` instead of invalid `storesb`/`storeub`/`storesh`/`storeuh` ([#54](https://github.com/garritfra/qbe-rs/pull/54))
 
 ### Migration guide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,6 @@ Instr::Load(Type::SignedHalfword, src)    // emits loadsh
 Instr::Load(Type::UnsignedHalfword, src)  // emits loaduh
 ```
 
-#### Sub-word stores (non-breaking)
-
-`Store` with `Type::SignedByte`, `Type::UnsignedByte`, `Type::SignedHalfword`, or `Type::UnsignedHalfword` previously emitted invalid instructions (`storesb`, `storeub`, etc.). These now correctly emit `storeb`/`storeh`. No code changes needed — existing code using these types will silently produce correct output.
-
 ## [3.0.0] - 2026-02-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 #### Sub-word loads
 
-`Load` with `Type::Byte` or `Type::Halfword` previously emitted invalid QBE IL (`loadb`/`loadh`). These now panic at runtime. Replace with the explicit signed/unsigned variant:
+`Load` with `Type::Byte` or `Type::Halfword` previously emitted invalid QBE IL (`loadb`/`loadh`). These now panic at runtime. Replace with the explicit signed/unsigned variant (see [QBE IL Memory reference](https://c9x.me/compile/doc/il.html#Memory)):
 
 ```rust
 // Before (produced invalid QBE IL)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,9 +220,20 @@ pub enum Instr<'a> {
     Alloc16(u128),
     /// Stores a value into memory pointed to by destination.
     /// `(type, destination, value)`
+    ///
+    /// For sub-word types, signed/unsigned variants (`SignedByte`, `UnsignedByte`,
+    /// `SignedHalfword`, `UnsignedHalfword`) are accepted and map to `storeb`/`storeh`,
+    /// since stores only truncate and don't distinguish signedness.
     Store(Type<'a>, Value, Value),
-    /// Loads a value from memory pointed to by source
+    /// Loads a value from memory pointed to by source.
     /// `(type, source)`
+    ///
+    /// # Panics
+    ///
+    /// Panics if called with [`Type::Byte`] or [`Type::Halfword`], because QBE requires
+    /// explicit sign/zero extension for sub-word loads. Use [`Type::SignedByte`] /
+    /// [`Type::UnsignedByte`] or [`Type::SignedHalfword`] / [`Type::UnsignedHalfword`]
+    /// instead.
     Load(Type<'a>, Value),
     /// `(source, destination, n)`
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,18 +379,20 @@ impl fmt::Display for Instr<'_> {
             Self::Alloc8(size) => write!(f, "alloc8 {size}"),
             Self::Alloc16(size) => write!(f, "alloc16 {size}"),
             Self::Store(ty, dest, value) => {
-                if matches!(ty, Type::Aggregate(_)) {
-                    unimplemented!("Store to an aggregate type");
-                }
-
-                write!(f, "store{ty} {value}, {dest}")
+                let suffix = match ty {
+                    Type::SignedByte | Type::UnsignedByte => "b".to_string(),
+                    Type::SignedHalfword | Type::UnsignedHalfword => "h".to_string(),
+                    Type::Aggregate(_) => unimplemented!("Store to an aggregate type"),
+                    _ => ty.to_string(),
+                };
+                write!(f, "store{suffix} {value}, {dest}")
             }
-            Self::Load(ty, src) => {
-                if matches!(ty, Type::Aggregate(_)) {
-                    unimplemented!("Load aggregate type");
-                }
-
-                write!(f, "load{ty} {src}")
+            Self::Load(ty, src) => match ty {
+                Type::Byte | Type::Halfword => panic!(
+                    "ambiguous sub-word load: use SignedByte/UnsignedByte or SignedHalfword/UnsignedHalfword"
+                ),
+                Type::Aggregate(_) => unimplemented!("Load aggregate type"),
+                _ => write!(f, "load{ty} {src}"),
             }
             Self::Blit(src, dst, n) => write!(f, "blit {src}, {dst}, {n}"),
             Self::Udiv(lhs, rhs) => write!(f, "udiv {lhs}, {rhs}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,8 @@ pub enum Instr<'a> {
     /// For sub-word types, signed/unsigned variants (`SignedByte`, `UnsignedByte`,
     /// `SignedHalfword`, `UnsignedHalfword`) are accepted and map to `storeb`/`storeh`,
     /// since stores only truncate and don't distinguish signedness.
+    ///
+    /// See the [QBE IL reference](https://c9x.me/compile/doc/il.html#Memory).
     Store(Type<'a>, Value, Value),
     /// Loads a value from memory pointed to by source.
     /// `(type, source)`
@@ -234,6 +236,8 @@ pub enum Instr<'a> {
     /// explicit sign/zero extension for sub-word loads. Use [`Type::SignedByte`] /
     /// [`Type::UnsignedByte`] or [`Type::SignedHalfword`] / [`Type::UnsignedHalfword`]
     /// instead.
+    ///
+    /// See the [QBE IL reference](https://c9x.me/compile/doc/il.html#Memory).
     Load(Type<'a>, Value),
     /// `(source, destination, n)`
     ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -891,3 +891,121 @@ fn assign_instr_aggregate_type_coercion() {
     assert_eq!(lines[1], "\t%human =l alloc8 24");
     assert_eq!(lines[2], "\t%result =:person call $new_person()");
 }
+
+#[test]
+fn load_valid_types() {
+    let src = Value::Temporary("addr".into());
+    assert_eq!(
+        format!("{}", Instr::Load(Type::SignedByte, src.clone())),
+        "loadsb %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Load(Type::UnsignedByte, src.clone())),
+        "loadub %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Load(Type::SignedHalfword, src.clone())),
+        "loadsh %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Load(Type::UnsignedHalfword, src.clone())),
+        "loaduh %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Load(Type::Word, src.clone())),
+        "loadw %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Load(Type::Long, src.clone())),
+        "loadl %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Load(Type::Single, src.clone())),
+        "loads %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Load(Type::Double, src.clone())),
+        "loadd %addr"
+    );
+}
+
+#[test]
+#[should_panic(expected = "ambiguous sub-word load")]
+fn load_byte_panics() {
+    let src = Value::Temporary("addr".into());
+    let _ = format!("{}", Instr::Load(Type::Byte, src));
+}
+
+#[test]
+#[should_panic(expected = "ambiguous sub-word load")]
+fn load_halfword_panics() {
+    let src = Value::Temporary("addr".into());
+    let _ = format!("{}", Instr::Load(Type::Halfword, src));
+}
+
+#[test]
+fn store_valid_types() {
+    let dest = Value::Temporary("addr".into());
+    let val = Value::Temporary("val".into());
+    assert_eq!(
+        format!("{}", Instr::Store(Type::Byte, dest.clone(), val.clone())),
+        "storeb %val, %addr"
+    );
+    assert_eq!(
+        format!(
+            "{}",
+            Instr::Store(Type::SignedByte, dest.clone(), val.clone())
+        ),
+        "storeb %val, %addr"
+    );
+    assert_eq!(
+        format!(
+            "{}",
+            Instr::Store(Type::UnsignedByte, dest.clone(), val.clone())
+        ),
+        "storeb %val, %addr"
+    );
+    assert_eq!(
+        format!(
+            "{}",
+            Instr::Store(Type::Halfword, dest.clone(), val.clone())
+        ),
+        "storeh %val, %addr"
+    );
+    assert_eq!(
+        format!(
+            "{}",
+            Instr::Store(Type::SignedHalfword, dest.clone(), val.clone())
+        ),
+        "storeh %val, %addr"
+    );
+    assert_eq!(
+        format!(
+            "{}",
+            Instr::Store(Type::UnsignedHalfword, dest.clone(), val.clone())
+        ),
+        "storeh %val, %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Store(Type::Word, dest.clone(), val.clone())),
+        "storew %val, %addr"
+    );
+    assert_eq!(
+        format!("{}", Instr::Store(Type::Long, dest.clone(), val.clone())),
+        "storel %val, %addr"
+    );
+    assert_eq!(
+        format!(
+            "{}",
+            Instr::Store(Type::Single, dest.clone(), val.clone())
+        ),
+        "stores %val, %addr"
+    );
+    assert_eq!(
+        format!(
+            "{}",
+            Instr::Store(Type::Double, dest.clone(), val.clone())
+        ),
+        "stored %val, %addr"
+    );
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -995,17 +995,11 @@ fn store_valid_types() {
         "storel %val, %addr"
     );
     assert_eq!(
-        format!(
-            "{}",
-            Instr::Store(Type::Single, dest.clone(), val.clone())
-        ),
+        format!("{}", Instr::Store(Type::Single, dest.clone(), val.clone())),
         "stores %val, %addr"
     );
     assert_eq!(
-        format!(
-            "{}",
-            Instr::Store(Type::Double, dest.clone(), val.clone())
-        ),
+        format!("{}", Instr::Store(Type::Double, dest.clone(), val.clone())),
         "stored %val, %addr"
     );
 }


### PR DESCRIPTION
## Summary

- `Load` with `Type::Byte`/`Type::Halfword` emitted invalid QBE instructions (`loadb`/`loadh`). Now panics, requiring users to specify `SignedByte`/`UnsignedByte` or `SignedHalfword`/`UnsignedHalfword`.
- `Store` with signed/unsigned sub-word types emitted invalid instructions (`storesb`/`storeub`/`storesh`/`storeuh`). Now correctly maps to `storeb`/`storeh`.
- Added tests for all load/store type combinations, including `#[should_panic]` tests for ambiguous sub-word loads.

### Breaking change

`Load(Type::Byte, ...)` and `Load(Type::Halfword, ...)` now panic at runtime. See the migration guide in CHANGELOG.md for details. Note that the previous behavior was a bug — it produced invalid QBE IL that would fail at the QBE compilation stage.

Closes #51

## Test plan

- [x] `cargo test` — all 36 unit tests + 10 doc-tests pass
- [x] `cargo clippy` — no warnings
- [ ] Verify downstream projects (e.g. Antimony) work with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)