### PR TITLE
Replace Type::Aggregate borrowed ref with Rc<TypeDef>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- BREAKING: `Type::Aggregate` now holds `Rc<TypeDef>` instead of `&'a TypeDef<'a>`, removing the lifetime parameter from all public types ([#50](https://github.com/garritfra/qbe-rs/issues/50))
-- BREAKING: `Module::types` is now `Vec<Rc<TypeDef>>` and `Module::add_type()` accepts `Rc<TypeDef>`
+- BREAKING: `Type::Aggregate` now holds `Arc<TypeDef>` instead of `&'a TypeDef<'a>`, removing the lifetime parameter from all public types ([#50](https://github.com/garritfra/qbe-rs/issues/50))
+- BREAKING: `Module::types` is now `Vec<Arc<TypeDef>>` and `Module::add_type()` accepts `Arc<TypeDef>`
 
 ### Added
 
-- `Type::aggregate(&Rc<TypeDef>)` convenience constructor
+- `Type::aggregate(&Arc<TypeDef>)` convenience constructor
+- `From<Arc<TypeDef>>` and `From<TypeDef>` implementations for `Type`
 
 ### Fixed
 
@@ -38,10 +39,10 @@ Instr::Load(Type::UnsignedHalfword, src)  // emits loaduh
 
 #### Aggregate types and lifetime removal
 
-`Type::Aggregate` now holds `Rc<TypeDef>` instead of a borrowed reference, and all lifetime parameters have been removed from the public API. Wrap your `TypeDef` in `Rc::new()` and use the `Type::aggregate()` constructor:
+`Type::Aggregate` now holds `Arc<TypeDef>` instead of a borrowed reference, and all lifetime parameters have been removed from the public API. Wrap your `TypeDef` in `Arc::new()` and use the `Type::aggregate()` constructor:
 
 ```rust
-use std::rc::Rc;
+use std::sync::Arc;
 
 // Before
 let typedef = TypeDef::Regular {
@@ -52,7 +53,7 @@ let typedef = TypeDef::Regular {
 let ty = Type::Aggregate(&typedef);
 
 // After
-let typedef = Rc::new(TypeDef::Regular {
+let typedef = Arc::new(TypeDef::Regular {
     ident: "person".into(),
     align: None,
     items: vec![(Type::Long, 1), (Type::Word, 2)],
@@ -60,14 +61,14 @@ let typedef = Rc::new(TypeDef::Regular {
 let ty = Type::aggregate(&typedef);
 ```
 
-`Module::add_type()` now accepts `Rc<TypeDef>`:
+`Module::add_type()` now accepts `Arc<TypeDef>`:
 
 ```rust
 // Before
 module.add_type(typedef);
 
 // After
-module.add_type(Rc::new(typedef));
+module.add_type(Arc::new(typedef));
 ```
 
 All lifetime annotations on qbe types can be removed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- BREAKING: `Type::Aggregate` now holds `Rc<TypeDef>` instead of `&'a TypeDef<'a>`, removing the lifetime parameter from all public types ([#50](https://github.com/garritfra/qbe-rs/issues/50))
+- BREAKING: `Module::types` is now `Vec<Rc<TypeDef>>` and `Module::add_type()` accepts `Rc<TypeDef>`
+
+### Added
+
+- `Type::aggregate(&Rc<TypeDef>)` convenience constructor
+
 ### Fixed
 
 - BREAKING: `Load` with `Type::Byte` or `Type::Halfword` now panics instead of emitting invalid `loadb`/`loadh` instructions. Use `SignedByte`/`UnsignedByte` or `SignedHalfword`/`UnsignedHalfword` instead. ([#51](https://github.com/garritfra/qbe-rs/issues/51), [#54](https://github.com/garritfra/qbe-rs/pull/54))
@@ -25,6 +34,56 @@ Instr::Load(Type::SignedByte, src)    // emits loadsb
 Instr::Load(Type::UnsignedByte, src)  // emits loadub
 Instr::Load(Type::SignedHalfword, src)    // emits loadsh
 Instr::Load(Type::UnsignedHalfword, src)  // emits loaduh
+```
+
+#### Aggregate types and lifetime removal
+
+`Type::Aggregate` now holds `Rc<TypeDef>` instead of a borrowed reference, and all lifetime parameters have been removed from the public API. Wrap your `TypeDef` in `Rc::new()` and use the `Type::aggregate()` constructor:
+
+```rust
+use std::rc::Rc;
+
+// Before
+let typedef = TypeDef::Regular {
+    ident: "person".into(),
+    align: None,
+    items: vec![(Type::Long, 1), (Type::Word, 2)],
+};
+let ty = Type::Aggregate(&typedef);
+
+// After
+let typedef = Rc::new(TypeDef::Regular {
+    ident: "person".into(),
+    align: None,
+    items: vec![(Type::Long, 1), (Type::Word, 2)],
+});
+let ty = Type::aggregate(&typedef);
+```
+
+`Module::add_type()` now accepts `Rc<TypeDef>`:
+
+```rust
+// Before
+module.add_type(typedef);
+
+// After
+module.add_type(Rc::new(typedef));
+```
+
+All lifetime annotations on qbe types can be removed:
+
+```rust
+// Before
+struct MyGenerator<'a> {
+    module: qbe::Module<'a>,
+    func: qbe::Function<'a>,
+}
+
+// After
+struct MyGenerator {
+    module: qbe::Module,
+    func: qbe::Function,
+}
 ```
 
 ## [3.0.0] - 2026-02-19

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,7 +600,7 @@ impl Type {
             Self::Word | Self::Single => 4,
             Self::Long | Self::Double => 8,
             Self::Aggregate(td) => {
-                fn size_of_items(s: &Type, items: &Vec<(Type, usize)>) -> u64 {
+                fn size_of_items(s: &Type, items: &[(Type, usize)]) -> u64 {
                     let mut offset = 0;
 
                     // calculation taken from: https://en.wikipedia.org/wiki/Data_structure_alignment#Computing%20padding
@@ -635,7 +635,7 @@ impl Type {
     pub fn align(&self) -> u64 {
         match self {
             Self::Aggregate(td) => {
-                fn align_of_items(items: &Vec<(Type, usize)>) -> u64 {
+                fn align_of_items(items: &[(Type, usize)]) -> u64 {
                     // the alignment of a type is the maximum alignment of its members
                     // when there's no members, the alignment is usuallly defined to be 1.
                     items.iter().map(|item| item.0.align()).max().unwrap_or(1)
@@ -660,7 +660,7 @@ impl Type {
 
                         // the alignment of a union is the maximum alignment of its variations
                         // when there's no variations, the alignment is usuallly defined to be 1.
-                        items.iter().map(align_of_items).max().unwrap_or(1)
+                        items.iter().map(|v| align_of_items(v)).max().unwrap_or(1)
                     }
                     TypeDef::Opaque { align, .. } => *align,
                 }
@@ -826,7 +826,7 @@ impl fmt::Display for TypeDef {
             write!(f, "align {align} ")?;
         }
 
-        fn format(items: &Vec<(Type, usize)>) -> String {
+        fn format(items: &[(Type, usize)]) -> String {
             items
                 .iter()
                 .map(|(ty, count)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,6 +474,24 @@ impl fmt::Display for Instr {
 /// assert_eq!(byte.size(), 1);
 /// ```
 ///
+/// ## Aggregate Types
+///
+/// Aggregate types reference a [`TypeDef`] via [`Rc`](std::rc::Rc):
+///
+/// ```rust
+/// use std::rc::Rc;
+/// use qbe::{TypeDef, Type};
+///
+/// let td = Rc::new(TypeDef::Regular {
+///     ident: "pair".into(),
+///     align: None,
+///     items: vec![(Type::Word, 2)],
+/// });
+///
+/// let ty = Type::aggregate(&td);
+/// assert_eq!(ty.size(), 8);
+/// ```
+///
 /// ## Type Conversions
 ///
 /// ```rust
@@ -506,7 +524,10 @@ pub enum Type {
     SignedHalfword,
     UnsignedHalfword,
 
-    /// Aggregate type with a specified name
+    /// Aggregate type referencing a [`TypeDef`].
+    ///
+    /// Use [`Type::aggregate`] to construct, or wrap a [`TypeDef`] in
+    /// [`Rc::new`](std::rc::Rc::new) and pass it directly.
     Aggregate(Rc<TypeDef>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 //! ```
 
 use std::fmt;
+use std::rc::Rc;
 
 #[cfg(test)]
 mod tests;
@@ -181,7 +182,7 @@ pub enum Cmp {
 /// let ret = Instr::Ret(Some(Value::Temporary("result".to_string())));
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum Instr<'a> {
+pub enum Instr {
     /// Adds values of two temporaries together
     Add(Value, Value),
     /// Subtracts the second value from the first one
@@ -193,7 +194,7 @@ pub enum Instr<'a> {
     /// Returns a remainder from division
     Rem(Value, Value),
     /// Performs a comparion between values
-    Cmp(Type<'a>, Cmp, Value, Value),
+    Cmp(Type, Cmp, Value, Value),
     /// Performs a bitwise AND on values
     And(Value, Value),
     /// Performs a bitwise OR on values
@@ -211,7 +212,7 @@ pub enum Instr<'a> {
     /// Unconditionally jumps to a label
     Jmp(String),
     /// Calls a function
-    Call(String, Vec<(Type<'a>, Value)>, Option<u64>),
+    Call(String, Vec<(Type, Value)>, Option<u64>),
     /// Allocates a 4-byte aligned area on the stack
     Alloc4(u32),
     /// Allocates a 8-byte aligned area on the stack
@@ -226,7 +227,7 @@ pub enum Instr<'a> {
     /// since stores only truncate and don't distinguish signedness.
     ///
     /// See the [QBE IL reference](https://c9x.me/compile/doc/il.html#Memory).
-    Store(Type<'a>, Value, Value),
+    Store(Type, Value, Value),
     /// Loads a value from memory pointed to by source.
     /// `(type, source)`
     ///
@@ -238,7 +239,7 @@ pub enum Instr<'a> {
     /// instead.
     ///
     /// See the [QBE IL reference](https://c9x.me/compile/doc/il.html#Memory).
-    Load(Type<'a>, Value),
+    Load(Type, Value),
     /// `(source, destination, n)`
     ///
     /// Copy `n` bytes from the source address to the destination address.
@@ -314,7 +315,7 @@ pub enum Instr<'a> {
     /// Initializes a variable argument list
     Vastart(Value),
     /// Fetches the next argument from a variable argument list
-    Vaarg(Type<'a>, Value),
+    Vaarg(Type, Value),
 
     // Phi instruction
     /// Selects value based on the control flow path into a block.
@@ -325,7 +326,7 @@ pub enum Instr<'a> {
     Hlt,
 }
 
-impl fmt::Display for Instr<'_> {
+impl fmt::Display for Instr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Add(lhs, rhs) => write!(f, "add {lhs}, {rhs}"),
@@ -487,7 +488,7 @@ impl fmt::Display for Instr<'_> {
 /// assert_eq!(abi, Type::Word);
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum Type<'a> {
+pub enum Type {
     // Base types
     Word,
     Long,
@@ -506,10 +507,30 @@ pub enum Type<'a> {
     UnsignedHalfword,
 
     /// Aggregate type with a specified name
-    Aggregate(&'a TypeDef<'a>),
+    Aggregate(Rc<TypeDef>),
 }
 
-impl Type<'_> {
+impl Type {
+    /// Creates a new [`Type::Aggregate`] from a reference-counted [`TypeDef`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::rc::Rc;
+    /// use qbe::{TypeDef, Type};
+    ///
+    /// let td = Rc::new(TypeDef::Regular {
+    ///     ident: "person".into(),
+    ///     align: None,
+    ///     items: vec![(Type::Long, 1)],
+    /// });
+    /// let ty = Type::aggregate(&td);
+    /// assert_eq!(format!("{ty}"), ":person");
+    /// ```
+    pub fn aggregate(td: &Rc<TypeDef>) -> Self {
+        Type::Aggregate(Rc::clone(td))
+    }
+
     /// Returns a C ABI type. Extended types are converted to closest base
     /// types
     pub fn into_abi(self) -> Self {
@@ -546,7 +567,7 @@ impl Type<'_> {
             Self::Word | Self::Single => 4,
             Self::Long | Self::Double => 8,
             Self::Aggregate(td) => {
-                fn size_of_items<'a>(s: &Type<'a>, items: &Vec<(Type<'a>, usize)>) -> u64 {
+                fn size_of_items(s: &Type, items: &Vec<(Type, usize)>) -> u64 {
                     let mut offset = 0;
 
                     // calculation taken from: https://en.wikipedia.org/wiki/Data_structure_alignment#Computing%20padding
@@ -564,7 +585,7 @@ impl Type<'_> {
                     offset + padding
                 }
 
-                match td {
+                match td.as_ref() {
                     TypeDef::Regular { items, .. } => size_of_items(self, items),
                     TypeDef::Union { variations, .. } => variations
                         .iter()
@@ -581,13 +602,13 @@ impl Type<'_> {
     pub fn align(&self) -> u64 {
         match self {
             Self::Aggregate(td) => {
-                fn align_of_items<'a>(items: &Vec<(Type<'a>, usize)>) -> u64 {
+                fn align_of_items(items: &Vec<(Type, usize)>) -> u64 {
                     // the alignment of a type is the maximum alignment of its members
                     // when there's no members, the alignment is usuallly defined to be 1.
                     items.iter().map(|item| item.0.align()).max().unwrap_or(1)
                 }
 
-                match td {
+                match td.as_ref() {
                     TypeDef::Regular { align, items, .. } => {
                         if let Some(align) = align {
                             return *align;
@@ -617,7 +638,7 @@ impl Type<'_> {
     }
 }
 
-impl fmt::Display for Type<'_> {
+impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Byte => write!(f, "b"),
@@ -659,19 +680,19 @@ impl fmt::Display for Value {
 
 /// QBE data definition
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-pub struct DataDef<'a> {
+pub struct DataDef {
     pub linkage: Linkage,
     pub name: String,
     pub align: Option<u64>,
-    pub items: Vec<(Type<'a>, DataItem)>,
+    pub items: Vec<(Type, DataItem)>,
 }
 
-impl<'a> DataDef<'a> {
+impl DataDef {
     pub fn new(
         linkage: Linkage,
         name: impl Into<String>,
         align: Option<u64>,
-        items: Vec<(Type<'a>, DataItem)>,
+        items: Vec<(Type, DataItem)>,
     ) -> Self {
         Self {
             linkage,
@@ -682,7 +703,7 @@ impl<'a> DataDef<'a> {
     }
 }
 
-impl fmt::Display for DataDef<'_> {
+impl fmt::Display for DataDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}data ${} = ", self.linkage, self.name)?;
 
@@ -730,16 +751,16 @@ impl fmt::Display for DataItem {
 
 /// QBE aggregate type definition
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum TypeDef<'a> {
+pub enum TypeDef {
     Regular {
         ident: String,
         align: Option<u64>,
-        items: Vec<(Type<'a>, usize)>,
+        items: Vec<(Type, usize)>,
     },
     Union {
         ident: String,
         align: Option<u64>,
-        variations: Vec<Vec<(Type<'a>, usize)>>,
+        variations: Vec<Vec<(Type, usize)>>,
     },
     Opaque {
         ident: String,
@@ -748,7 +769,7 @@ pub enum TypeDef<'a> {
     },
 }
 
-impl TypeDef<'_> {
+impl TypeDef {
     pub fn ident(&self) -> &str {
         match self {
             TypeDef::Regular { ident, .. } => ident,
@@ -758,7 +779,7 @@ impl TypeDef<'_> {
     }
 }
 
-impl fmt::Display for TypeDef<'_> {
+impl fmt::Display for TypeDef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "type :{} = ", self.ident())?;
 
@@ -772,7 +793,7 @@ impl fmt::Display for TypeDef<'_> {
             write!(f, "align {align} ")?;
         }
 
-        fn format<'a>(items: &Vec<(Type<'a>, usize)>) -> String {
+        fn format(items: &Vec<(Type, usize)>) -> String {
             items
                 .iter()
                 .map(|(ty, count)| {
@@ -806,12 +827,12 @@ impl fmt::Display for TypeDef<'_> {
 
 /// An IR statement
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum Statement<'a> {
-    Assign(Value, Type<'a>, Instr<'a>),
-    Volatile(Instr<'a>),
+pub enum Statement {
+    Assign(Value, Type, Instr),
+    Volatile(Instr),
 }
 
-impl fmt::Display for Statement<'_> {
+impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Assign(temp, ty, instr) => {
@@ -870,22 +891,22 @@ impl fmt::Display for Statement<'_> {
 /// assert!(block.jumps());
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-pub struct Block<'a> {
+pub struct Block {
     /// Label before the block
     pub label: String,
 
     /// A list of statements in the block
-    pub items: Vec<BlockItem<'a>>,
+    pub items: Vec<BlockItem>,
 }
 
 /// See [`Block::items`];
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum BlockItem<'a> {
-    Statement(Statement<'a>),
+pub enum BlockItem {
+    Statement(Statement),
     Comment(String),
 }
 
-impl fmt::Display for BlockItem<'_> {
+impl fmt::Display for BlockItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Statement(stmt) => write!(f, "{stmt}"),
@@ -894,19 +915,19 @@ impl fmt::Display for BlockItem<'_> {
     }
 }
 
-impl<'a> Block<'a> {
+impl Block {
     pub fn add_comment(&mut self, contents: impl Into<String>) {
         self.items.push(BlockItem::Comment(contents.into()));
     }
 
     /// Adds a new instruction to the block
-    pub fn add_instr(&mut self, instr: Instr<'a>) {
+    pub fn add_instr(&mut self, instr: Instr) {
         self.items
             .push(BlockItem::Statement(Statement::Volatile(instr)));
     }
 
     /// Adds a new instruction assigned to a temporary
-    pub fn assign_instr(&mut self, temp: Value, ty: Type<'a>, instr: Instr<'a>) {
+    pub fn assign_instr(&mut self, temp: Value, ty: Type, instr: Instr) {
         let final_type = match instr {
             Instr::Call(_, _, _) => ty,
             _ => ty.into_base(),
@@ -929,7 +950,7 @@ impl<'a> Block<'a> {
     }
 }
 
-impl fmt::Display for Block<'_> {
+impl fmt::Display for Block {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "@{}", self.label)?;
 
@@ -992,7 +1013,7 @@ impl fmt::Display for Block<'_> {
 /// start.add_instr(Instr::Ret(Some(Value::Temporary("is_zero".to_string()))));
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-pub struct Function<'a> {
+pub struct Function {
     /// Function's linkage
     pub linkage: Linkage,
 
@@ -1000,22 +1021,22 @@ pub struct Function<'a> {
     pub name: String,
 
     /// Function arguments
-    pub arguments: Vec<(Type<'a>, Value)>,
+    pub arguments: Vec<(Type, Value)>,
 
     /// Return type
-    pub return_ty: Option<Type<'a>>,
+    pub return_ty: Option<Type>,
 
     /// Labelled blocks
-    pub blocks: Vec<Block<'a>>,
+    pub blocks: Vec<Block>,
 }
 
-impl<'a> Function<'a> {
+impl Function {
     /// Instantiates an empty function and returns it
     pub fn new(
         linkage: Linkage,
         name: impl Into<String>,
-        arguments: Vec<(Type<'a>, Value)>,
-        return_ty: Option<Type<'a>>,
+        arguments: Vec<(Type, Value)>,
+        return_ty: Option<Type>,
     ) -> Self {
         Function {
             linkage,
@@ -1027,7 +1048,7 @@ impl<'a> Function<'a> {
     }
 
     /// Adds a new empty block with a specified label and returns a reference to it
-    pub fn add_block(&mut self, label: impl Into<String>) -> &mut Block<'a> {
+    pub fn add_block(&mut self, label: impl Into<String>) -> &mut Block {
         self.blocks.push(Block {
             label: label.into(),
             items: Vec::new(),
@@ -1040,14 +1061,14 @@ impl<'a> Function<'a> {
         since = "3.0.0",
         note = "Use `self.blocks.last()` or `self.blocks.last_mut()` instead."
     )]
-    pub fn last_block(&mut self) -> &Block<'a> {
+    pub fn last_block(&mut self) -> &Block {
         self.blocks
             .last()
             .expect("Function must have at least one block")
     }
 
     /// Adds a new instruction to the last block
-    pub fn add_instr(&mut self, instr: Instr<'a>) {
+    pub fn add_instr(&mut self, instr: Instr) {
         self.blocks
             .last_mut()
             .expect("Last block must be present")
@@ -1055,7 +1076,7 @@ impl<'a> Function<'a> {
     }
 
     /// Adds a new instruction assigned to a temporary
-    pub fn assign_instr(&mut self, temp: Value, ty: Type<'a>, instr: Instr<'a>) {
+    pub fn assign_instr(&mut self, temp: Value, ty: Type, instr: Instr) {
         self.blocks
             .last_mut()
             .expect("Last block must be present")
@@ -1063,7 +1084,7 @@ impl<'a> Function<'a> {
     }
 }
 
-impl fmt::Display for Function<'_> {
+impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}function", self.linkage)?;
         if let Some(ty) = &self.return_ty {
@@ -1251,15 +1272,15 @@ impl fmt::Display for Linkage {
 /// module.add_function(main);
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-pub struct Module<'a> {
-    pub functions: Vec<Function<'a>>,
-    pub types: Vec<TypeDef<'a>>,
-    pub data: Vec<DataDef<'a>>,
+pub struct Module {
+    pub functions: Vec<Function>,
+    pub types: Vec<Rc<TypeDef>>,
+    pub data: Vec<DataDef>,
 }
 
-impl<'a> Module<'a> {
+impl Module {
     /// Creates a new module
-    pub fn new() -> Module<'a> {
+    pub fn new() -> Module {
         Module {
             functions: Vec::new(),
             types: Vec::new(),
@@ -1269,26 +1290,24 @@ impl<'a> Module<'a> {
 
     /// Adds a function to the module, returning a reference to it for later
     /// modification
-    pub fn add_function(&mut self, func: Function<'a>) -> &mut Function<'a> {
+    pub fn add_function(&mut self, func: Function) -> &mut Function {
         self.functions.push(func);
         self.functions.last_mut().unwrap()
     }
 
-    /// Adds a type definition to the module, returning a reference to it for
-    /// later modification
-    pub fn add_type(&mut self, def: TypeDef<'a>) -> &mut TypeDef<'a> {
+    /// Adds a type definition to the module
+    pub fn add_type(&mut self, def: Rc<TypeDef>) {
         self.types.push(def);
-        self.types.last_mut().unwrap()
     }
 
     /// Adds a data definition to the module
-    pub fn add_data(&mut self, data: DataDef<'a>) -> &mut DataDef<'a> {
+    pub fn add_data(&mut self, data: DataDef) -> &mut DataDef {
         self.data.push(data);
         self.data.last_mut().unwrap()
     }
 }
 
-impl fmt::Display for Module<'_> {
+impl fmt::Display for Module {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for ty in self.types.iter() {
             writeln!(f, "{ty}")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! ```
 
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[cfg(test)]
 mod tests;
@@ -476,13 +476,13 @@ impl fmt::Display for Instr {
 ///
 /// ## Aggregate Types
 ///
-/// Aggregate types reference a [`TypeDef`] via [`Rc`](std::rc::Rc):
+/// Aggregate types reference a [`TypeDef`] via [`Arc`](std::sync::Arc):
 ///
 /// ```rust
-/// use std::rc::Rc;
+/// use std::sync::Arc;
 /// use qbe::{TypeDef, Type};
 ///
-/// let td = Rc::new(TypeDef::Regular {
+/// let td = Arc::new(TypeDef::Regular {
 ///     ident: "pair".into(),
 ///     align: None,
 ///     items: vec![(Type::Word, 2)],
@@ -527,8 +527,20 @@ pub enum Type {
     /// Aggregate type referencing a [`TypeDef`].
     ///
     /// Use [`Type::aggregate`] to construct, or wrap a [`TypeDef`] in
-    /// [`Rc::new`](std::rc::Rc::new) and pass it directly.
-    Aggregate(Rc<TypeDef>),
+    /// [`Arc::new`](std::sync::Arc::new) and pass it directly.
+    Aggregate(Arc<TypeDef>),
+}
+
+impl From<Arc<TypeDef>> for Type {
+    fn from(td: Arc<TypeDef>) -> Self {
+        Type::Aggregate(td)
+    }
+}
+
+impl From<TypeDef> for Type {
+    fn from(td: TypeDef) -> Self {
+        Type::Aggregate(Arc::new(td))
+    }
 }
 
 impl Type {
@@ -537,10 +549,10 @@ impl Type {
     /// # Examples
     ///
     /// ```rust
-    /// use std::rc::Rc;
+    /// use std::sync::Arc;
     /// use qbe::{TypeDef, Type};
     ///
-    /// let td = Rc::new(TypeDef::Regular {
+    /// let td = Arc::new(TypeDef::Regular {
     ///     ident: "person".into(),
     ///     align: None,
     ///     items: vec![(Type::Long, 1)],
@@ -548,8 +560,8 @@ impl Type {
     /// let ty = Type::aggregate(&td);
     /// assert_eq!(format!("{ty}"), ":person");
     /// ```
-    pub fn aggregate(td: &Rc<TypeDef>) -> Self {
-        Type::Aggregate(Rc::clone(td))
+    pub fn aggregate(td: &Arc<TypeDef>) -> Self {
+        Type::Aggregate(Arc::clone(td))
     }
 
     /// Returns a C ABI type. Extended types are converted to closest base
@@ -1295,7 +1307,7 @@ impl fmt::Display for Linkage {
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct Module {
     pub functions: Vec<Function>,
-    pub types: Vec<Rc<TypeDef>>,
+    pub types: Vec<Arc<TypeDef>>,
     pub data: Vec<DataDef>,
 }
 
@@ -1317,7 +1329,7 @@ impl Module {
     }
 
     /// Adds a type definition to the module
-    pub fn add_type(&mut self, def: Rc<TypeDef>) {
+    pub fn add_type(&mut self, def: Arc<TypeDef>) {
         self.types.push(def);
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 use crate::*;
+use std::rc::Rc;
 
 #[test]
 fn qbe_value() {
@@ -162,7 +163,7 @@ fn typedef_regular() {
     let formatted = format!("{typedef_with_align}");
     assert_eq!(formatted, "type :person = align 8 { l, w 2, b }");
 
-    let ty = Type::Aggregate(&typedef);
+    let ty = Type::aggregate(&Rc::new(typedef));
     let formatted = format!("{ty}");
     assert_eq!(formatted, ":person");
 }
@@ -193,7 +194,7 @@ fn typedef_union() {
     let formatted = format!("{typedef_with_align}");
     assert_eq!(formatted, "type :data = align 8 { { l, w 2, b } { l 2 } }");
 
-    let ty = Type::Aggregate(&typedef);
+    let ty = Type::aggregate(&Rc::new(typedef));
     let formatted = format!("{ty}");
     assert_eq!(formatted, ":data");
 }
@@ -209,7 +210,7 @@ fn typedef_opaque() {
     let formatted = format!("{typedef}");
     assert_eq!(formatted, "type :data = align 8 { 64 }");
 
-    let ty = Type::Aggregate(&typedef);
+    let ty = Type::aggregate(&Rc::new(typedef));
     let formatted = format!("{ty}");
     assert_eq!(formatted, ":data");
 }
@@ -232,26 +233,26 @@ fn type_size() {
         align: None,
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
     };
-    let aggregate = Type::Aggregate(&typedef_regular);
+    let aggregate = Type::aggregate(&Rc::new(typedef_regular));
     assert_eq!(aggregate.size(), 24);
 
-    let typedef_union = TypeDef::Union {
+    let typedef_union = Rc::new(TypeDef::Union {
         ident: "data".into(),
         align: None,
         variations: vec![
             vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
             vec![(Type::Long, 5)],
         ],
-    };
-    let aggregate = Type::Aggregate(&typedef_union);
+    });
+    let aggregate = Type::aggregate(&typedef_union);
     assert_eq!(aggregate.size(), 40);
 
-    let typedef_opaque = TypeDef::Opaque {
+    let typedef_opaque = Rc::new(TypeDef::Opaque {
         ident: "data".into(),
         align: 8,
         size: 64,
-    };
-    let aggregate = Type::Aggregate(&typedef_opaque);
+    });
+    let aggregate = Type::aggregate(&typedef_opaque);
     assert_eq!(aggregate.size(), 64);
 }
 
@@ -273,51 +274,51 @@ fn type_align() {
         align: None,
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
     };
-    let aggregate = Type::Aggregate(&typedef_regular);
+    let aggregate = Type::aggregate(&Rc::new(typedef_regular));
     assert_eq!(aggregate.align(), 8);
 
-    let typedef_union = TypeDef::Union {
+    let typedef_union = Rc::new(TypeDef::Union {
         ident: "data".into(),
         align: None,
         variations: vec![
             vec![(Type::Word, 1), (Type::Word, 2), (Type::Byte, 1)],
             vec![(Type::Long, 5)],
         ],
-    };
-    let aggregate = Type::Aggregate(&typedef_union);
+    });
+    let aggregate = Type::aggregate(&typedef_union);
     assert_eq!(aggregate.align(), 8);
 
-    let typedef_opaque = TypeDef::Opaque {
+    let typedef_opaque = Rc::new(TypeDef::Opaque {
         ident: "data".into(),
         align: 8,
         size: 64,
-    };
-    let aggregate = Type::Aggregate(&typedef_opaque);
+    });
+    let aggregate = Type::aggregate(&typedef_opaque);
     assert_eq!(aggregate.align(), 8);
 }
 
 #[test]
 fn type_size_nested_aggregate() {
-    let inner = TypeDef::Regular {
+    let inner = Rc::new(TypeDef::Regular {
         ident: "dog".into(),
         align: None,
         items: vec![(Type::Long, 2)],
-    };
-    let inner_aggregate = Type::Aggregate(&inner);
+    });
+    let inner_aggregate = Type::aggregate(&inner);
 
     assert!(inner_aggregate.size() == 16);
 
-    let typedef = TypeDef::Regular {
+    let typedef = Rc::new(TypeDef::Regular {
         ident: "person".into(),
         align: None,
         items: vec![
             (Type::Long, 1),
             (Type::Word, 2),
             (Type::Byte, 1),
-            (Type::Aggregate(&inner), 1),
+            (Type::aggregate(&inner), 1),
         ],
-    };
-    let aggregate = Type::Aggregate(&typedef);
+    });
+    let aggregate = Type::aggregate(&typedef);
 
     assert_eq!(aggregate.size(), 40);
 }
@@ -330,12 +331,12 @@ fn type_into_abi() {
     unchanged(Type::Long);
     unchanged(Type::Single);
     unchanged(Type::Double);
-    let typedef = TypeDef::Regular {
+    let typedef = Rc::new(TypeDef::Regular {
         ident: "foo".into(),
         align: None,
         items: Vec::new(),
-    };
-    unchanged(Type::Aggregate(&typedef));
+    });
+    unchanged(Type::aggregate(&typedef));
 
     // Extended types are transformed into closest base types
     assert_eq!(Type::Byte.into_abi(), Type::Word);
@@ -362,12 +363,12 @@ fn type_into_base() {
     assert_eq!(Type::Halfword.into_base(), Type::Word);
     assert_eq!(Type::UnsignedHalfword.into_base(), Type::Word);
     assert_eq!(Type::SignedHalfword.into_base(), Type::Word);
-    let typedef = TypeDef::Regular {
+    let typedef = Rc::new(TypeDef::Regular {
         ident: "foo".into(),
         align: None,
         items: Vec::new(),
-    };
-    assert_eq!(Type::Aggregate(&typedef).into_base(), Type::Long);
+    });
+    assert_eq!(Type::aggregate(&typedef).into_base(), Type::Long);
 }
 
 #[test]
@@ -407,11 +408,11 @@ fn module_fmt_order() {
     let mut module = Module::new();
 
     // Add a type definition to the module
-    let typedef = TypeDef::Regular {
+    let typedef = Rc::new(TypeDef::Regular {
         ident: "test_type".into(),
         align: None,
         items: vec![(Type::Long, 1)],
-    };
+    });
     module.add_type(typedef);
 
     // Add a function to the module
@@ -866,21 +867,21 @@ fn assign_instr_aggregate_type_coercion() {
         items: Vec::new(),
     };
 
-    let typedef = TypeDef::Regular {
+    let typedef = Rc::new(TypeDef::Regular {
         ident: "person".into(),
         align: None,
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
-    };
+    });
 
     block.assign_instr(
         Value::Temporary("human".into()),
-        Type::Aggregate(&typedef),
-        Instr::Alloc8(Type::Aggregate(&typedef).size()),
+        Type::aggregate(&typedef),
+        Instr::Alloc8(Type::aggregate(&typedef).size()),
     );
 
     block.assign_instr(
         Value::Temporary("result".into()),
-        Type::Aggregate(&typedef),
+        Type::aggregate(&typedef),
         Instr::Call("new_person".into(), vec![], None),
     );
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use crate::*;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[test]
 fn qbe_value() {
@@ -163,7 +163,7 @@ fn typedef_regular() {
     let formatted = format!("{typedef_with_align}");
     assert_eq!(formatted, "type :person = align 8 { l, w 2, b }");
 
-    let ty = Type::aggregate(&Rc::new(typedef));
+    let ty = Type::aggregate(&Arc::new(typedef));
     let formatted = format!("{ty}");
     assert_eq!(formatted, ":person");
 }
@@ -194,7 +194,7 @@ fn typedef_union() {
     let formatted = format!("{typedef_with_align}");
     assert_eq!(formatted, "type :data = align 8 { { l, w 2, b } { l 2 } }");
 
-    let ty = Type::aggregate(&Rc::new(typedef));
+    let ty = Type::aggregate(&Arc::new(typedef));
     let formatted = format!("{ty}");
     assert_eq!(formatted, ":data");
 }
@@ -210,7 +210,7 @@ fn typedef_opaque() {
     let formatted = format!("{typedef}");
     assert_eq!(formatted, "type :data = align 8 { 64 }");
 
-    let ty = Type::aggregate(&Rc::new(typedef));
+    let ty = Type::aggregate(&Arc::new(typedef));
     let formatted = format!("{ty}");
     assert_eq!(formatted, ":data");
 }
@@ -233,10 +233,10 @@ fn type_size() {
         align: None,
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
     };
-    let aggregate = Type::aggregate(&Rc::new(typedef_regular));
+    let aggregate = Type::aggregate(&Arc::new(typedef_regular));
     assert_eq!(aggregate.size(), 24);
 
-    let typedef_union = Rc::new(TypeDef::Union {
+    let typedef_union = Arc::new(TypeDef::Union {
         ident: "data".into(),
         align: None,
         variations: vec![
@@ -247,7 +247,7 @@ fn type_size() {
     let aggregate = Type::aggregate(&typedef_union);
     assert_eq!(aggregate.size(), 40);
 
-    let typedef_opaque = Rc::new(TypeDef::Opaque {
+    let typedef_opaque = Arc::new(TypeDef::Opaque {
         ident: "data".into(),
         align: 8,
         size: 64,
@@ -274,10 +274,10 @@ fn type_align() {
         align: None,
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],
     };
-    let aggregate = Type::aggregate(&Rc::new(typedef_regular));
+    let aggregate = Type::aggregate(&Arc::new(typedef_regular));
     assert_eq!(aggregate.align(), 8);
 
-    let typedef_union = Rc::new(TypeDef::Union {
+    let typedef_union = Arc::new(TypeDef::Union {
         ident: "data".into(),
         align: None,
         variations: vec![
@@ -288,7 +288,7 @@ fn type_align() {
     let aggregate = Type::aggregate(&typedef_union);
     assert_eq!(aggregate.align(), 8);
 
-    let typedef_opaque = Rc::new(TypeDef::Opaque {
+    let typedef_opaque = Arc::new(TypeDef::Opaque {
         ident: "data".into(),
         align: 8,
         size: 64,
@@ -299,7 +299,7 @@ fn type_align() {
 
 #[test]
 fn type_size_nested_aggregate() {
-    let inner = Rc::new(TypeDef::Regular {
+    let inner = Arc::new(TypeDef::Regular {
         ident: "dog".into(),
         align: None,
         items: vec![(Type::Long, 2)],
@@ -308,7 +308,7 @@ fn type_size_nested_aggregate() {
 
     assert!(inner_aggregate.size() == 16);
 
-    let typedef = Rc::new(TypeDef::Regular {
+    let typedef = Arc::new(TypeDef::Regular {
         ident: "person".into(),
         align: None,
         items: vec![
@@ -331,7 +331,7 @@ fn type_into_abi() {
     unchanged(Type::Long);
     unchanged(Type::Single);
     unchanged(Type::Double);
-    let typedef = Rc::new(TypeDef::Regular {
+    let typedef = Arc::new(TypeDef::Regular {
         ident: "foo".into(),
         align: None,
         items: Vec::new(),
@@ -363,7 +363,7 @@ fn type_into_base() {
     assert_eq!(Type::Halfword.into_base(), Type::Word);
     assert_eq!(Type::UnsignedHalfword.into_base(), Type::Word);
     assert_eq!(Type::SignedHalfword.into_base(), Type::Word);
-    let typedef = Rc::new(TypeDef::Regular {
+    let typedef = Arc::new(TypeDef::Regular {
         ident: "foo".into(),
         align: None,
         items: Vec::new(),
@@ -408,7 +408,7 @@ fn module_fmt_order() {
     let mut module = Module::new();
 
     // Add a type definition to the module
-    let typedef = Rc::new(TypeDef::Regular {
+    let typedef = Arc::new(TypeDef::Regular {
         ident: "test_type".into(),
         align: None,
         items: vec![(Type::Long, 1)],
@@ -867,7 +867,7 @@ fn assign_instr_aggregate_type_coercion() {
         items: Vec::new(),
     };
 
-    let typedef = Rc::new(TypeDef::Regular {
+    let typedef = Arc::new(TypeDef::Regular {
         ident: "person".into(),
         align: None,
         items: vec![(Type::Long, 1), (Type::Word, 2), (Type::Byte, 1)],


### PR DESCRIPTION
## Summary

- Replace `Type::Aggregate(&'a TypeDef<'a>)` with `Type::Aggregate(Rc<TypeDef>)`, removing the `'a` lifetime parameter from all public types (`Type`, `TypeDef`, `Instr`, `Statement`, `BlockItem`, `Block`, `Function`, `DataDef`, `Module`)
- Change `Module::types` to `Vec<Rc<TypeDef>>` so module and `Type::Aggregate` can share the same allocation
- Add `Type::aggregate(&Rc<TypeDef>)` convenience constructor

Closes #50

## Test plan

- [x] All 32 unit tests pass
- [x] All 12 doc-tests pass
- [x] `cargo clippy` clean (pre-existing warnings only)
- [x] `hello_world` example compiles
- [x] No `'a` lifetime remains in public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)