### PR TITLE
Feature/#56/newtype value variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- BREAKING: `Value::Temporary` now holds a `Temporary(String)` instead of a `String`
+- BREAKING: `Value::Global` now holds a `Global(String)` instead of a `String`
+- BREAKING: `Statement::Assign`'s first type is now a `Temporary` instead of a `Value`
+- BREAKING: `Block::assign_instr`'s first argument is now `impl Into<String>` instead of `Value`
+
 ### Added
 
+- `Value` provides a `temporary` convenience constructor
+- `Value` provides a `global` convenience constructor
 - New example `tiny_basic`: a BASIC-subset compiler that demonstrates an
   end-to-end source-to-IL pipeline (lexer, parser, codegen). Closes
   [#9](https://github.com/garritfra/qbe-rs/issues/9)

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -15,7 +15,7 @@ fn generate_add_func(module: &mut Module) {
 
     func.add_block("start");
     func.assign_instr(
-        Value::Temporary("c".into()),
+        "c",
         Type::Word,
         Instr::Add(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
@@ -29,7 +29,7 @@ fn generate_main_func(module: &mut Module) {
 
     func.add_block("start");
     func.assign_instr(
-        Value::Temporary("r".into()),
+        "r",
         Type::Word,
         Instr::Call(
             "add".into(),

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -7,8 +7,8 @@ fn generate_add_func(module: &mut Module) {
         Linkage::private(),
         "add",
         vec![
-            (Type::Word, Value::Temporary("a".into())),
-            (Type::Word, Value::Temporary("b".into())),
+            (Type::Word, Value::temporary("a")),
+            (Type::Word, Value::temporary("b")),
         ],
         Some(Type::Word),
     );
@@ -17,9 +17,9 @@ fn generate_add_func(module: &mut Module) {
     func.assign_instr(
         "c",
         Type::Word,
-        Instr::Add(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Add(Value::temporary("a"), Value::temporary("b")),
     );
-    func.add_instr(Instr::Ret(Some(Value::Temporary("c".into()))));
+    func.add_instr(Instr::Ret(Some(Value::temporary("c"))));
 
     module.add_function(func);
 }
@@ -40,8 +40,8 @@ fn generate_main_func(module: &mut Module) {
     func.add_instr(Instr::Call(
         "printf".into(),
         vec![
-            (Type::Long, Value::Global("fmt".into())),
-            (Type::Word, Value::Temporary("r".into())),
+            (Type::Long, Value::global("fmt")),
+            (Type::Word, Value::temporary("r")),
         ],
         Some(1),
     ));

--- a/examples/tiny_basic/main.rs
+++ b/examples/tiny_basic/main.rs
@@ -395,13 +395,13 @@ impl Codegen {
     }
 
     fn fresh_temp(&mut self) -> Value {
-        let v = Value::Temporary(format!("t{}", self.next_temp));
+        let v = Value::temporary(&format!("t{}", self.next_temp));
         self.next_temp += 1;
         v
     }
     fn fresh_temp_with_name(&mut self) -> (Value, String) {
         let name = format!("t{}", self.next_temp);
-        let v = Value::Temporary(name.clone());
+        let v = Value::temporary(name.as_str());
         self.next_temp += 1;
         (v, name)
     }
@@ -414,7 +414,7 @@ impl Codegen {
                 func.assign_instr(
                     destname,
                     Type::Word,
-                    Instr::Load(Type::Word, Value::Temporary(name.clone())),
+                    Instr::Load(Type::Word, Value::temporary(name.as_str())),
                 );
                 dest
             }
@@ -449,17 +449,14 @@ impl Codegen {
         match stmt {
             Stmt::Let(name, e) => {
                 let v = self.lower_expr(func, e);
-                func.add_instr(Instr::Store(Type::Word, Value::Temporary(name.clone()), v));
+                func.add_instr(Instr::Store(Type::Word, Value::temporary(name.as_str()), v));
                 func.add_instr(Instr::Jmp(next_label.to_string()));
             }
             Stmt::Print(e) => {
                 let v = self.lower_expr(func, e);
                 func.add_instr(Instr::Call(
                     "printf".to_string(),
-                    vec![
-                        (Type::Long, Value::Global("fmt_int".to_string())),
-                        (Type::Word, v),
-                    ],
+                    vec![(Type::Long, Value::global("fmt_int")), (Type::Word, v)],
                     Some(1),
                 ));
                 func.add_instr(Instr::Jmp(next_label.to_string()));
@@ -511,7 +508,7 @@ impl Codegen {
             main.assign_instr(v.clone(), Type::Long, Instr::Alloc4(4));
             main.add_instr(Instr::Store(
                 Type::Word,
-                Value::Temporary(v.clone()),
+                Value::temporary(v),
                 Value::Const(0),
             ));
         }

--- a/examples/tiny_basic/main.rs
+++ b/examples/tiny_basic/main.rs
@@ -399,14 +399,20 @@ impl Codegen {
         self.next_temp += 1;
         v
     }
+    fn fresh_temp_with_name(&mut self) -> (Value, String) {
+        let name = format!("t{}", self.next_temp);
+        let v = Value::Temporary(name.clone());
+        self.next_temp += 1;
+        (v, name)
+    }
 
     fn lower_expr(&mut self, func: &mut Function, e: &Expr) -> Value {
         match e {
             Expr::Num(n) => Value::Const(*n as u64),
             Expr::Var(name) => {
-                let dest = self.fresh_temp();
+                let (dest, destname) = self.fresh_temp_with_name();
                 func.assign_instr(
-                    dest.clone(),
+                    destname,
                     Type::Word,
                     Instr::Load(Type::Word, Value::Temporary(name.clone())),
                 );
@@ -415,7 +421,7 @@ impl Codegen {
             Expr::BinOp(op, l, r) => {
                 let lv = self.lower_expr(func, l);
                 let rv = self.lower_expr(func, r);
-                let dest = self.fresh_temp();
+                let (dest, destname) = self.fresh_temp_with_name();
                 let instr = match op {
                     BinOp::Add => Instr::Add(lv, rv),
                     BinOp::Sub => Instr::Sub(lv, rv),
@@ -428,7 +434,7 @@ impl Codegen {
                     BinOp::Le => Instr::Cmp(Type::Word, Cmp::Sle, lv, rv),
                     BinOp::Ge => Instr::Cmp(Type::Word, Cmp::Sge, lv, rv),
                 };
-                func.assign_instr(dest.clone(), Type::Word, instr);
+                func.assign_instr(destname, Type::Word, instr);
                 dest
             }
         }
@@ -502,7 +508,7 @@ impl Codegen {
 
         main.add_block("entry");
         for v in &vars {
-            main.assign_instr(Value::Temporary(v.clone()), Type::Long, Instr::Alloc4(4));
+            main.assign_instr(v.clone(), Type::Long, Instr::Alloc4(4));
             main.add_instr(Instr::Store(
                 Type::Word,
                 Value::Temporary(v.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //!     Linkage::public(),
 //!     "add",
 //!     vec![
-//!         (Type::Word, Value::Temporary("a".to_string())),
-//!         (Type::Word, Value::Temporary("b".to_string())),
+//!         (Type::Word, Value::temporary("a")),
+//!         (Type::Word, Value::temporary("b")),
 //!     ],
 //!     Some(Type::Word),
 //! );
@@ -42,13 +42,13 @@
 //!     "sum",
 //!     Type::Word,
 //!     Instr::Add(
-//!         Value::Temporary("a".to_string()),
-//!         Value::Temporary("b".to_string()),
+//!         Value::temporary("a"),
+//!         Value::temporary("b"),
 //!     ),
 //! );
 //!
 //! // Return the sum
-//! block.add_instr(Instr::Ret(Some(Value::Temporary("sum".to_string()))));
+//! block.add_instr(Instr::Ret(Some(Value::temporary("sum"))));
 //!
 //! // Add the function to the module
 //! module.add_function(func);
@@ -85,15 +85,15 @@ mod tests;
 /// let slt_instr = Instr::Cmp(
 ///     Type::Word,
 ///     Cmp::Slt,
-///     Value::Temporary("a".to_string()),
-///     Value::Temporary("b".to_string()),
+///     Value::temporary("a"),
+///     Value::temporary("b"),
 /// );
 ///
 /// // Check if two values are equal
 /// let eq_instr = Instr::Cmp(
 ///     Type::Word,
 ///     Cmp::Eq,
-///     Value::Temporary("x".to_string()),
+///     Value::temporary("x"),
 ///     Value::Const(0),
 /// );
 /// ```
@@ -135,13 +135,13 @@ pub enum Cmp {
 ///
 /// // Addition: %result = %a + %b
 /// let add = Instr::Add(
-///     Value::Temporary("a".to_string()),
-///     Value::Temporary("b".to_string()),
+///     Value::temporary("a"),
+///     Value::temporary("b"),
 /// );
 ///
 /// // Multiplication: %result = %x * 5
 /// let mul = Instr::Mul(
-///     Value::Temporary("x".to_string()),
+///     Value::temporary("x"),
 ///     Value::Const(5),
 /// );
 /// ```
@@ -156,14 +156,14 @@ pub enum Cmp {
 /// // Store a word to memory: store %value, %ptr
 /// let store = Instr::Store(
 ///     Type::Word,
-///     Value::Temporary("ptr".to_string()),
-///     Value::Temporary("value".to_string()),
+///     Value::temporary("ptr"),
+///     Value::temporary("value"),
 /// );
 ///
 /// // Load a word from memory: %result = load %ptr
 /// let load = Instr::Load(
 ///     Type::Word,
-///     Value::Temporary("ptr".to_string()),
+///     Value::temporary("ptr"),
 /// );
 /// ```
 ///
@@ -173,13 +173,13 @@ pub enum Cmp {
 ///
 /// // Conditional jump based on %condition
 /// let branch = Instr::Jnz(
-///     Value::Temporary("condition".to_string()),
+///     Value::temporary("condition"),
 ///     "true_branch".to_string(),
 ///     "false_branch".to_string(),
 /// );
 ///
 /// // Return a value from a function
-/// let ret = Instr::Ret(Some(Value::Temporary("result".to_string())));
+/// let ret = Instr::Ret(Some(Value::temporary("result")));
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Instr {
@@ -689,16 +689,44 @@ impl fmt::Display for Type {
         }
     }
 }
+/// QBE temporary
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Temporary(String);
+
+impl fmt::Display for Temporary {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "%{}", self.0)
+    }
+}
+
+/// QBE global
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Global(String);
+
+impl fmt::Display for Global {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "${}", self.0)
+    }
+}
 
 /// QBE value that is accepted by instructions
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Value {
     /// `%`-temporary
-    Temporary(String),
+    Temporary(Temporary),
     /// `$`-global
-    Global(String),
+    Global(Global),
     /// Constant
     Const(u64),
+}
+
+impl Value {
+    pub fn temporary(name: impl Into<String>) -> Value {
+        Value::Temporary(Temporary(name.into()))
+    }
+    pub fn global(name: impl Into<String>) -> Value {
+        Value::Global(Global(name.into()))
+    }
 }
 
 impl From<u64> for Value {
@@ -710,8 +738,8 @@ impl From<u64> for Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Temporary(name) => write!(f, "%{name}"),
-            Self::Global(name) => write!(f, "${name}"),
+            Self::Temporary(name) => write!(f, "{name}"),
+            Self::Global(name) => write!(f, "{name}"),
             Self::Const(value) => write!(f, "{value}"),
         }
     }
@@ -867,7 +895,7 @@ impl fmt::Display for TypeDef {
 /// An IR statement
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Statement {
-    Assign(String, Type, Instr),
+    Assign(Temporary, Type, Instr),
     Volatile(Instr),
 }
 
@@ -875,7 +903,7 @@ impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Assign(temp, ty, instr) => {
-                write!(f, "%{temp} ={ty} {instr}")
+                write!(f, "{temp} ={ty} {instr}")
             }
             Self::Volatile(instr) => write!(f, "{instr}"),
         }
@@ -907,7 +935,7 @@ impl fmt::Display for Statement {
 ///     "i",
 ///     Type::Word,
 ///     Instr::Add(
-///         Value::Temporary("i".to_string()),
+///         Value::temporary("i"),
 ///         Value::Const(1),
 ///     ),
 /// );
@@ -917,8 +945,8 @@ impl fmt::Display for Statement {
 ///     "sum",
 ///     Type::Word,
 ///     Instr::Add(
-///         Value::Temporary("sum".to_string()),
-///         Value::Temporary("value".to_string()),
+///         Value::temporary("sum"),
+///         Value::temporary("value"),
 ///     ),
 /// );
 ///
@@ -972,7 +1000,7 @@ impl Block {
         };
 
         self.items.push(BlockItem::Statement(Statement::Assign(
-            temp.into(),
+            Temporary(temp.into()),
             final_type,
             instr,
         )));
@@ -1020,7 +1048,7 @@ impl fmt::Display for Block {
 /// let mut is_even = Function::new(
 ///     Linkage::public(),
 ///     "is_even",
-///     vec![(Type::Word, Value::Temporary("n".to_string()))],
+///     vec![(Type::Word, Value::temporary("n"))],
 ///     Some(Type::Word), // Returns 1 if even, 0 if odd
 /// );
 ///
@@ -1032,7 +1060,7 @@ impl fmt::Display for Block {
 ///     "remainder",
 ///     Type::Word,
 ///     Instr::And(
-///         Value::Temporary("n".to_string()),
+///         Value::temporary("n"),
 ///         Value::Const(1),
 ///     ),
 /// );
@@ -1044,13 +1072,13 @@ impl fmt::Display for Block {
 ///     Instr::Cmp(
 ///         Type::Word,
 ///         Cmp::Eq,
-///         Value::Temporary("remainder".to_string()),
+///         Value::temporary("remainder"),
 ///         Value::Const(0),
 ///     ),
 /// );
 ///
 /// // Return the result
-/// start.add_instr(Instr::Ret(Some(Value::Temporary("is_zero".to_string()))));
+/// start.add_instr(Instr::Ret(Some(Value::temporary("is_zero"))));
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct Function {
@@ -1308,7 +1336,7 @@ impl fmt::Display for Linkage {
 ///     Type::Word,
 ///     Instr::Call(
 ///         "printf".to_string(),
-///         vec![(Type::Long, Value::Global("hello".to_string()))],
+///         vec![(Type::Long, Value::global("hello"))],
 ///         None,
 ///     ),
 /// );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,7 +689,7 @@ impl fmt::Display for Type {
         }
     }
 }
-/// QBE temporary
+/// QBE %temporary
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Temporary(String);
 
@@ -699,7 +699,7 @@ impl fmt::Display for Temporary {
     }
 }
 
-/// QBE global
+/// QBE $global
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Global(String);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! // Add two arguments and store result in "sum"
 //! block.assign_instr(
-//!     Value::Temporary("sum".to_string()),
+//!     "sum",
 //!     Type::Word,
 //!     Instr::Add(
 //!         Value::Temporary("a".to_string()),
@@ -867,7 +867,7 @@ impl fmt::Display for TypeDef {
 /// An IR statement
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Statement {
-    Assign(Value, Type, Instr),
+    Assign(String, Type, Instr),
     Volatile(Instr),
 }
 
@@ -875,11 +875,7 @@ impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Assign(temp, ty, instr) => {
-                assert!(
-                    matches!(temp, Value::Temporary(_)),
-                    "assignment target must be a temporary, got {temp:?}"
-                );
-                write!(f, "{temp} ={ty} {instr}")
+                write!(f, "%{temp} ={ty} {instr}")
             }
             Self::Volatile(instr) => write!(f, "{instr}"),
         }
@@ -908,7 +904,7 @@ impl fmt::Display for Statement {
 ///
 /// // Increment loop counter: %i = %i + 1
 /// block.assign_instr(
-///     Value::Temporary("i".to_string()),
+///     "i",
 ///     Type::Word,
 ///     Instr::Add(
 ///         Value::Temporary("i".to_string()),
@@ -918,7 +914,7 @@ impl fmt::Display for Statement {
 ///
 /// // Update sum: %sum = %sum + %value
 /// block.assign_instr(
-///     Value::Temporary("sum".to_string()),
+///     "sum",
 ///     Type::Word,
 ///     Instr::Add(
 ///         Value::Temporary("sum".to_string()),
@@ -969,14 +965,16 @@ impl Block {
     }
 
     /// Adds a new instruction assigned to a temporary
-    pub fn assign_instr(&mut self, temp: Value, ty: Type, instr: Instr) {
+    pub fn assign_instr(&mut self, temp: impl Into<String>, ty: Type, instr: Instr) {
         let final_type = match instr {
             Instr::Call(_, _, _) => ty,
             _ => ty.into_base(),
         };
 
         self.items.push(BlockItem::Statement(Statement::Assign(
-            temp, final_type, instr,
+            temp.into(),
+            final_type,
+            instr,
         )));
     }
 
@@ -1031,7 +1029,7 @@ impl fmt::Display for Block {
 ///
 /// // Calculate n % 2 (by using n & 1)
 /// start.assign_instr(
-///     Value::Temporary("remainder".to_string()),
+///     "remainder",
 ///     Type::Word,
 ///     Instr::And(
 ///         Value::Temporary("n".to_string()),
@@ -1041,7 +1039,7 @@ impl fmt::Display for Block {
 ///
 /// // Check if remainder is 0 (even number)
 /// start.assign_instr(
-///     Value::Temporary("is_zero".to_string()),
+///     "is_zero",
 ///     Type::Word,
 ///     Instr::Cmp(
 ///         Type::Word,
@@ -1126,11 +1124,11 @@ impl Function {
     /// # Panics
     ///
     /// Panics if the function has no blocks.
-    pub fn assign_instr(&mut self, temp: Value, ty: Type, instr: Instr) {
+    pub fn assign_instr(&mut self, temp: impl Into<String>, ty: Type, instr: Instr) {
         self.blocks
             .last_mut()
             .expect("Last block must be present")
-            .assign_instr(temp, ty, instr);
+            .assign_instr(temp.into(), ty, instr);
     }
 }
 
@@ -1306,7 +1304,7 @@ impl fmt::Display for Linkage {
 ///
 /// // Call printf with the string: %r = call $printf(l $hello)
 /// start.assign_instr(
-///     Value::Temporary("r".to_string()),
+///     "r",
 ///     Type::Word,
 ///     Instr::Call(
 ///         "printf".to_string(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,7 +39,7 @@ fn block() {
         items: vec![
             BlockItem::Comment("Comment".into()),
             BlockItem::Statement(Statement::Assign(
-                Value::Temporary("foo".into()),
+                "foo".into(),
                 Type::Word,
                 Instr::Add(Value::Const(2), Value::Const(2)),
             )),
@@ -513,14 +513,14 @@ fn comparison_types() {
 #[test]
 fn unsigned_arithmetic_instructions() {
     let udiv = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Udiv(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
     assert_eq!(format!("{udiv}"), "%result =w udiv %a, %b");
 
     let urem = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Long,
         Instr::Urem(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
@@ -530,21 +530,21 @@ fn unsigned_arithmetic_instructions() {
 #[test]
 fn shift_instructions() {
     let sar = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Sar(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
     assert_eq!(format!("{sar}"), "%result =w sar %a, %b");
 
     let shr = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Long,
         Instr::Shr(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
     assert_eq!(format!("{shr}"), "%result =l shr %a, %b");
 
     let shl = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Shl(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
@@ -554,14 +554,14 @@ fn shift_instructions() {
 #[test]
 fn cast_instruction() {
     let cast_int_to_float = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Single,
         Instr::Cast(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{cast_int_to_float}"), "%result =s cast %a");
 
     let cast_float_to_int = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Cast(Value::Temporary("f".into())),
     );
@@ -571,42 +571,42 @@ fn cast_instruction() {
 #[test]
 fn extension_operations() {
     let extsw = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Long,
         Instr::Extsw(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{extsw}"), "%result =l extsw %a");
 
     let extuw = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Long,
         Instr::Extuw(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{extuw}"), "%result =l extuw %a");
 
     let extsh = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Extsh(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{extsh}"), "%result =w extsh %a");
 
     let extuh = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Extuh(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{extuh}"), "%result =w extuh %a");
 
     let extsb = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Extsb(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{extsb}"), "%result =w extsb %a");
 
     let extub = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Extub(Value::Temporary("a".into())),
     );
@@ -616,14 +616,14 @@ fn extension_operations() {
 #[test]
 fn float_precision_conversion() {
     let exts = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Double,
         Instr::Exts(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{exts}"), "%result =d exts %a");
 
     let truncd = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Single,
         Instr::Truncd(Value::Temporary("a".into())),
     );
@@ -633,56 +633,56 @@ fn float_precision_conversion() {
 #[test]
 fn float_integer_conversions() {
     let stosi = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Stosi(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{stosi}"), "%result =w stosi %a");
 
     let stoui = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Stoui(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{stoui}"), "%result =w stoui %a");
 
     let dtosi = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Long,
         Instr::Dtosi(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{dtosi}"), "%result =l dtosi %a");
 
     let dtoui = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Long,
         Instr::Dtoui(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{dtoui}"), "%result =l dtoui %a");
 
     let swtof = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Single,
         Instr::Swtof(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{swtof}"), "%result =s swtof %a");
 
     let uwtof = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Single,
         Instr::Uwtof(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{uwtof}"), "%result =s uwtof %a");
 
     let sltof = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Double,
         Instr::Sltof(Value::Temporary("a".into())),
     );
     assert_eq!(format!("{sltof}"), "%result =d sltof %a");
 
     let ultof = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Double,
         Instr::Ultof(Value::Temporary("a".into())),
     );
@@ -695,7 +695,7 @@ fn variadic_instructions() {
     assert_eq!(format!("{vastart}"), "vastart %ap");
 
     let vaarg = Statement::Assign(
-        Value::Temporary("arg".into()),
+        "arg".into(),
         Type::Word,
         Instr::Vaarg(Type::Word, Value::Temporary("ap".into())),
     );
@@ -711,7 +711,7 @@ fn phi_instruction() {
     assert_eq!(format!("{phi}"), "phi @ift 2, @iff %3");
 
     let phi = Statement::Assign(
-        Value::Temporary("result".into()),
+        "result".into(),
         Type::Word,
         Instr::Phi(vec![
             ("start".into(), Value::Temporary("1".into())),
@@ -728,7 +728,7 @@ fn phi_instruction() {
     assert_eq!(format!("{phi}"), "phi @case1 10, @case2 20, @case3 30");
 
     let phi = Statement::Assign(
-        Value::Temporary("merged".into()),
+        "merged".into(),
         Type::Long,
         Instr::Phi(vec![
             ("path_a".into(), Value::Temporary("x".into())),
@@ -814,28 +814,28 @@ fn complex_block_with_multiple_instructions() {
 
     // Add unsigned division
     block.assign_instr(
-        Value::Temporary("udiv_result".into()),
+        "udiv_result",
         Type::Word,
         Instr::Udiv(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
 
     // Add a shift operation
     block.assign_instr(
-        Value::Temporary("shift_result".into()),
+        "shift_result",
         Type::Word,
         Instr::Shl(Value::Temporary("a".into()), Value::Temporary("b".into())),
     );
 
     // Add a cast operation
     block.assign_instr(
-        Value::Temporary("cast_result".into()),
+        "cast_result",
         Type::Single,
         Instr::Cast(Value::Temporary("shift_result".into())),
     );
 
     // Add a comparison (unordered)
     block.assign_instr(
-        Value::Temporary("cmp_result".into()),
+        "cmp_result",
         Type::Word,
         Instr::Cmp(
             Type::Single,
@@ -874,13 +874,13 @@ fn assign_instr_aggregate_type_coercion() {
     });
 
     block.assign_instr(
-        Value::Temporary("human".into()),
+        "human",
         Type::aggregate(&typedef),
         Instr::Alloc8(Type::aggregate(&typedef).size()),
     );
 
     block.assign_instr(
-        Value::Temporary("result".into()),
+        "result",
         Type::aggregate(&typedef),
         Instr::Call("new_person".into(), vec![], None),
     );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,10 +12,15 @@ use std::sync::Arc;
 
 #[test]
 fn qbe_value() {
-    let val = Value::Temporary("temp42".into());
+    let val = Value::Temporary(Temporary("temp42".into()));
+    assert_eq!(format!("{val}"), "%temp42");
+    let val = Value::temporary("temp42");
     assert_eq!(format!("{val}"), "%temp42");
 
-    let val = Value::Global("main".into());
+    let val = Value::Global(Global("main".into()));
+    assert_eq!(format!("{val}"), "$main");
+
+    let val = Value::global("main");
     assert_eq!(format!("{val}"), "$main");
 
     let val = Value::Const(1337);
@@ -39,12 +44,12 @@ fn block() {
         items: vec![
             BlockItem::Comment("Comment".into()),
             BlockItem::Statement(Statement::Assign(
-                "foo".into(),
+                Temporary("foo".into()),
                 Type::Word,
                 Instr::Add(Value::Const(2), Value::Const(2)),
             )),
-            BlockItem::Statement(Statement::Volatile(Instr::Ret(Some(Value::Temporary(
-                "foo".into(),
+            BlockItem::Statement(Statement::Volatile(Instr::Ret(Some(Value::temporary(
+                "foo",
             ))))),
         ],
     };
@@ -62,8 +67,8 @@ fn instr_blit() {
     let blk = Block {
         label: "start".into(),
         items: vec![BlockItem::Statement(Statement::Volatile(Instr::Blit(
-            Value::Temporary("src".into()),
-            Value::Temporary("dst".into()),
+            Value::temporary("src"),
+            Value::temporary("dst"),
             4,
         )))],
     };
@@ -393,7 +398,7 @@ fn variadic_call() {
     let instr = Instr::Call(
         "printf".into(),
         vec![
-            (Type::Long, Value::Global("fmt".into())),
+            (Type::Long, Value::global("fmt")),
             (Type::Word, Value::Const(0)),
         ],
         Some(1),
@@ -463,16 +468,16 @@ fn comparison_types() {
     let ordered_cmp = Statement::Volatile(Instr::Cmp(
         Type::Double,
         Cmp::O,
-        Value::Temporary("a".into()),
-        Value::Temporary("b".into()),
+        Value::temporary("a"),
+        Value::temporary("b"),
     ));
     assert_eq!(format!("{ordered_cmp}"), "cod %a, %b");
 
     let unordered_cmp = Statement::Volatile(Instr::Cmp(
         Type::Single,
         Cmp::Uo,
-        Value::Temporary("a".into()),
-        Value::Temporary("b".into()),
+        Value::temporary("a"),
+        Value::temporary("b"),
     ));
     assert_eq!(format!("{unordered_cmp}"), "cuos %a, %b");
 
@@ -480,32 +485,32 @@ fn comparison_types() {
     let unsigned_lt = Statement::Volatile(Instr::Cmp(
         Type::Word,
         Cmp::Ult,
-        Value::Temporary("a".into()),
-        Value::Temporary("b".into()),
+        Value::temporary("a"),
+        Value::temporary("b"),
     ));
     assert_eq!(format!("{unsigned_lt}"), "cultw %a, %b");
 
     let unsigned_le = Statement::Volatile(Instr::Cmp(
         Type::Long,
         Cmp::Ule,
-        Value::Temporary("a".into()),
-        Value::Temporary("b".into()),
+        Value::temporary("a"),
+        Value::temporary("b"),
     ));
     assert_eq!(format!("{unsigned_le}"), "culel %a, %b");
 
     let unsigned_gt = Statement::Volatile(Instr::Cmp(
         Type::Word,
         Cmp::Ugt,
-        Value::Temporary("a".into()),
-        Value::Temporary("b".into()),
+        Value::temporary("a"),
+        Value::temporary("b"),
     ));
     assert_eq!(format!("{unsigned_gt}"), "cugtw %a, %b");
 
     let unsigned_ge = Statement::Volatile(Instr::Cmp(
         Type::Long,
         Cmp::Uge,
-        Value::Temporary("a".into()),
-        Value::Temporary("b".into()),
+        Value::temporary("a"),
+        Value::temporary("b"),
     ));
     assert_eq!(format!("{unsigned_ge}"), "cugel %a, %b");
 }
@@ -513,16 +518,16 @@ fn comparison_types() {
 #[test]
 fn unsigned_arithmetic_instructions() {
     let udiv = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Udiv(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Udiv(Value::temporary("a"), Value::temporary("b")),
     );
     assert_eq!(format!("{udiv}"), "%result =w udiv %a, %b");
 
     let urem = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Long,
-        Instr::Urem(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Urem(Value::temporary("a"), Value::temporary("b")),
     );
     assert_eq!(format!("{urem}"), "%result =l urem %a, %b");
 }
@@ -530,23 +535,23 @@ fn unsigned_arithmetic_instructions() {
 #[test]
 fn shift_instructions() {
     let sar = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Sar(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Sar(Value::temporary("a"), Value::temporary("b")),
     );
     assert_eq!(format!("{sar}"), "%result =w sar %a, %b");
 
     let shr = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Long,
-        Instr::Shr(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Shr(Value::temporary("a"), Value::temporary("b")),
     );
     assert_eq!(format!("{shr}"), "%result =l shr %a, %b");
 
     let shl = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Shl(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Shl(Value::temporary("a"), Value::temporary("b")),
     );
     assert_eq!(format!("{shl}"), "%result =w shl %a, %b");
 }
@@ -554,16 +559,16 @@ fn shift_instructions() {
 #[test]
 fn cast_instruction() {
     let cast_int_to_float = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Single,
-        Instr::Cast(Value::Temporary("a".into())),
+        Instr::Cast(Value::temporary("a")),
     );
     assert_eq!(format!("{cast_int_to_float}"), "%result =s cast %a");
 
     let cast_float_to_int = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Cast(Value::Temporary("f".into())),
+        Instr::Cast(Value::temporary("f")),
     );
     assert_eq!(format!("{cast_float_to_int}"), "%result =w cast %f");
 }
@@ -571,44 +576,44 @@ fn cast_instruction() {
 #[test]
 fn extension_operations() {
     let extsw = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Long,
-        Instr::Extsw(Value::Temporary("a".into())),
+        Instr::Extsw(Value::temporary("a")),
     );
     assert_eq!(format!("{extsw}"), "%result =l extsw %a");
 
     let extuw = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Long,
-        Instr::Extuw(Value::Temporary("a".into())),
+        Instr::Extuw(Value::temporary("a")),
     );
     assert_eq!(format!("{extuw}"), "%result =l extuw %a");
 
     let extsh = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Extsh(Value::Temporary("a".into())),
+        Instr::Extsh(Value::temporary("a")),
     );
     assert_eq!(format!("{extsh}"), "%result =w extsh %a");
 
     let extuh = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Extuh(Value::Temporary("a".into())),
+        Instr::Extuh(Value::temporary("a")),
     );
     assert_eq!(format!("{extuh}"), "%result =w extuh %a");
 
     let extsb = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Extsb(Value::Temporary("a".into())),
+        Instr::Extsb(Value::temporary("a")),
     );
     assert_eq!(format!("{extsb}"), "%result =w extsb %a");
 
     let extub = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Extub(Value::Temporary("a".into())),
+        Instr::Extub(Value::temporary("a")),
     );
     assert_eq!(format!("{extub}"), "%result =w extub %a");
 }
@@ -616,16 +621,16 @@ fn extension_operations() {
 #[test]
 fn float_precision_conversion() {
     let exts = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Double,
-        Instr::Exts(Value::Temporary("a".into())),
+        Instr::Exts(Value::temporary("a")),
     );
     assert_eq!(format!("{exts}"), "%result =d exts %a");
 
     let truncd = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Single,
-        Instr::Truncd(Value::Temporary("a".into())),
+        Instr::Truncd(Value::temporary("a")),
     );
     assert_eq!(format!("{truncd}"), "%result =s truncd %a");
 }
@@ -633,71 +638,71 @@ fn float_precision_conversion() {
 #[test]
 fn float_integer_conversions() {
     let stosi = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Stosi(Value::Temporary("a".into())),
+        Instr::Stosi(Value::temporary("a")),
     );
     assert_eq!(format!("{stosi}"), "%result =w stosi %a");
 
     let stoui = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
-        Instr::Stoui(Value::Temporary("a".into())),
+        Instr::Stoui(Value::temporary("a")),
     );
     assert_eq!(format!("{stoui}"), "%result =w stoui %a");
 
     let dtosi = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Long,
-        Instr::Dtosi(Value::Temporary("a".into())),
+        Instr::Dtosi(Value::temporary("a")),
     );
     assert_eq!(format!("{dtosi}"), "%result =l dtosi %a");
 
     let dtoui = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Long,
-        Instr::Dtoui(Value::Temporary("a".into())),
+        Instr::Dtoui(Value::temporary("a")),
     );
     assert_eq!(format!("{dtoui}"), "%result =l dtoui %a");
 
     let swtof = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Single,
-        Instr::Swtof(Value::Temporary("a".into())),
+        Instr::Swtof(Value::temporary("a")),
     );
     assert_eq!(format!("{swtof}"), "%result =s swtof %a");
 
     let uwtof = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Single,
-        Instr::Uwtof(Value::Temporary("a".into())),
+        Instr::Uwtof(Value::temporary("a")),
     );
     assert_eq!(format!("{uwtof}"), "%result =s uwtof %a");
 
     let sltof = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Double,
-        Instr::Sltof(Value::Temporary("a".into())),
+        Instr::Sltof(Value::temporary("a")),
     );
     assert_eq!(format!("{sltof}"), "%result =d sltof %a");
 
     let ultof = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Double,
-        Instr::Ultof(Value::Temporary("a".into())),
+        Instr::Ultof(Value::temporary("a")),
     );
     assert_eq!(format!("{ultof}"), "%result =d ultof %a");
 }
 
 #[test]
 fn variadic_instructions() {
-    let vastart = Statement::Volatile(Instr::Vastart(Value::Temporary("ap".into())));
+    let vastart = Statement::Volatile(Instr::Vastart(Value::temporary("ap")));
     assert_eq!(format!("{vastart}"), "vastart %ap");
 
     let vaarg = Statement::Assign(
-        "arg".into(),
+        Temporary("arg".into()),
         Type::Word,
-        Instr::Vaarg(Type::Word, Value::Temporary("ap".into())),
+        Instr::Vaarg(Type::Word, Value::temporary("ap")),
     );
     assert_eq!(format!("{vaarg}"), "%arg =w vaargw %ap");
 }
@@ -706,16 +711,16 @@ fn variadic_instructions() {
 fn phi_instruction() {
     let phi = Instr::Phi(vec![
         ("ift".into(), Value::Const(2)),
-        ("iff".into(), Value::Temporary("3".into())),
+        ("iff".into(), Value::temporary("3")),
     ]);
     assert_eq!(format!("{phi}"), "phi @ift 2, @iff %3");
 
     let phi = Statement::Assign(
-        "result".into(),
+        Temporary("result".into()),
         Type::Word,
         Instr::Phi(vec![
-            ("start".into(), Value::Temporary("1".into())),
-            ("loop".into(), Value::Global("tmp".into())),
+            ("start".into(), Value::temporary("1")),
+            ("loop".into(), Value::global("tmp")),
         ]),
     );
     assert_eq!(format!("{phi}"), "%result =w phi @start %1, @loop $tmp");
@@ -728,12 +733,12 @@ fn phi_instruction() {
     assert_eq!(format!("{phi}"), "phi @case1 10, @case2 20, @case3 30");
 
     let phi = Statement::Assign(
-        "merged".into(),
+        Temporary("merged".to_string()),
         Type::Long,
         Instr::Phi(vec![
-            ("path_a".into(), Value::Temporary("x".into())),
-            ("path_b".into(), Value::Temporary("y".into())),
-            ("path_c".into(), Value::Global("global_val".into())),
+            ("path_a".into(), Value::temporary("x")),
+            ("path_b".into(), Value::temporary("y")),
+            ("path_c".into(), Value::global("global_val")),
             ("path_d".into(), Value::Const(42)),
         ]),
     );
@@ -816,21 +821,21 @@ fn complex_block_with_multiple_instructions() {
     block.assign_instr(
         "udiv_result",
         Type::Word,
-        Instr::Udiv(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Udiv(Value::temporary("a"), Value::temporary("b")),
     );
 
     // Add a shift operation
     block.assign_instr(
         "shift_result",
         Type::Word,
-        Instr::Shl(Value::Temporary("a".into()), Value::Temporary("b".into())),
+        Instr::Shl(Value::temporary("a"), Value::temporary("b")),
     );
 
     // Add a cast operation
     block.assign_instr(
         "cast_result",
         Type::Single,
-        Instr::Cast(Value::Temporary("shift_result".into())),
+        Instr::Cast(Value::temporary("shift_result")),
     );
 
     // Add a comparison (unordered)
@@ -840,8 +845,8 @@ fn complex_block_with_multiple_instructions() {
         Instr::Cmp(
             Type::Single,
             Cmp::Uo,
-            Value::Temporary("cast_result".into()),
-            Value::Temporary("x".into()),
+            Value::temporary("cast_result"),
+            Value::temporary("x"),
         ),
     );
 
@@ -895,7 +900,7 @@ fn assign_instr_aggregate_type_coercion() {
 
 #[test]
 fn load_valid_types() {
-    let src = Value::Temporary("addr".into());
+    let src = Value::temporary("addr");
     assert_eq!(
         format!("{}", Instr::Load(Type::SignedByte, src.clone())),
         "loadsb %addr"
@@ -933,21 +938,21 @@ fn load_valid_types() {
 #[test]
 #[should_panic(expected = "ambiguous sub-word load")]
 fn load_byte_panics() {
-    let src = Value::Temporary("addr".into());
+    let src = Value::temporary("addr");
     let _ = format!("{}", Instr::Load(Type::Byte, src));
 }
 
 #[test]
 #[should_panic(expected = "ambiguous sub-word load")]
 fn load_halfword_panics() {
-    let src = Value::Temporary("addr".into());
+    let src = Value::temporary("addr");
     let _ = format!("{}", Instr::Load(Type::Halfword, src));
 }
 
 #[test]
 fn store_valid_types() {
-    let dest = Value::Temporary("addr".into());
-    let val = Value::Temporary("val".into());
+    let dest = Value::temporary("addr");
+    let val = Value::temporary("val");
     assert_eq!(
         format!("{}", Instr::Store(Type::Byte, dest.clone(), val.clone())),
         "storeb %val, %addr"


### PR DESCRIPTION
Fixes #56 (partially)

### Description

This PR addresses one item from #56 
namely that `Instr::Assign` panics when its assignee is not a temp.

This proposal adds NewType `String` wrappers for temporaries and globals, such that nodes that allow only one of them can take them directly instead of a `Value`.

some convenience constructors are also added to `Value` for constructing them.

### Changes proposed in this pull request

- Add two new types: `Temporary` and `Global`,
- These replace the `String` values of their corresponding `Value` variants
- These types implement `fmt::Display`, their implementation is lifted from `Value`.
- `Value` gets two new constructors: `temporary(name: impl Into<String>)` and `global(name: impl Into<string>)`
- `Statement::Assign` now takes a `Temporary` instead of a `Value` to avoid invalid state
- change `Block::assign_instr` to take an `impl Into<String>` to improve ergonomics
- test cases check formatting for both manual construction of a `Value::Temporary(Temporary)`, `Value::Global(Global)`,
  and the new constructors

### ToDo

- [x] I've read the [CONTRIBUTING.md](https://github.com/garritfra/qbe-rs/blob/main/CONTRIBUTING.md) guidelines before submitting this PR
- [x] Proposed feature/fix is sufficiently tested
- [x] Proposed feature/fix is sufficiently documented
- [x] The "Unreleased" section in the changelog has been updated, if applicable